### PR TITLE
Add initial .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+install: "pip install -r requirements.txt"
+script: make tests


### PR DESCRIPTION
This is a relatively simple .travis.yml file. We can extend it as we go. It is valid according to https://lint.travis-ci.org/ . Currently, it will fail due to testifycompat being required for the tests to run. However, we can simply disable automatic builds on the travis website until we sort out that issue.