### PR TITLE
Add MANIFESTS.in and pin thriftpy version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include *.md *.py *.txt
+recursive-include clog *.py *.thrift
+recursive-include testing *.py
+recursive-include tests *.py

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='yelp-clog',
-    version='2.2.9',
+    version='2.2.10',
     description='A package which provides logging and reading from scribe.',
     author='Yelp Infra Team',
     author_email='infra@yelp.com',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'boto>=2.0.0',
         'future>=0.14.0',
-        'thriftpy',
+        'thriftpy==0.1.15',
         'PyStaticConfiguration >= 0.8',
         'simplejson',
     ]


### PR DESCRIPTION
yelp_clog apparantly is not compatible with the latest version of
thriftpy. So we pin to 0.1.15. Also add a MANIFESTS.in to ensure we are
including all necessary files in our module.