### PR TITLE
Fix scribify on py3

### DIFF
--- a/clog/utils.py
+++ b/clog/utils.py
@@ -16,12 +16,20 @@ import bz2
 import gzip
 import re
 
-DISALLOWED_STREAM_CHARACTERS_RE = re.compile(r'[^-_a-zA-Z0-9]')
+from future.utils import text_to_native_str
+
+
+DISALLOWED_STREAM_CHARACTERS_RE = re.compile(u'[^-_a-zA-Z0-9]')
 
 
 def scribify(stream_name):
     """Convert an arbitrary stream name to be appropriate to use as a Scribe category name."""
-    return DISALLOWED_STREAM_CHARACTERS_RE.sub('_', stream_name)
+    # First convert the stream_name to text so we can do string operations
+    if isinstance(stream_name, bytes):
+        stream_name = stream_name.decode('UTF-8')
+    stream_name = DISALLOWED_STREAM_CHARACTERS_RE.sub('_', stream_name)
+    # Now convert into native string for scribe
+    return text_to_native_str(stream_name)
 
 
 def open_compressed_file(filename, mode='r'):

--- a/tests/test_clog.py
+++ b/tests/test_clog.py
@@ -109,7 +109,7 @@ class CLogTestBase(object):
         self.log_instance.handlers = [self.handler]
 
 
-class CLogHandlerTest(CLogTestBase):
+class TestCLogHandler(CLogTestBase):
 
     def test_handler_preserves_exceptions(self):
         """Test exception preservation a la 18848"""
@@ -122,7 +122,7 @@ class CLogHandlerTest(CLogTestBase):
         assert 1 == len([message for message in self.logger.list_lines(self.STREAM_NAME) if "example log message" in message])
 
 
-class MiscellaneousCLogMethodsTest(CLogTestBase):
+class TestMiscellaneousCLogMethods(CLogTestBase):
     def test_get_scribed_logger(self):
         log = get_scribed_logger("unit_test_scribed", logging.INFO, fmt=self.SIMPLE_FORMAT, clogger_object=self.logger)
         log.info("This is a test")
@@ -134,9 +134,11 @@ class MiscellaneousCLogMethodsTest(CLogTestBase):
         assert 1 == len([message for message in self.logger.list_lines("unit_test_scribed") if message == "This is a test"])
 
     def test_scribify(self):
-        assert scribify("this is a test") == "this_is_a_test"
-        assert scribify("this\0is a-test\n\n") == "this_is_a-test__"
-        assert scribify(u'int\xe9rna\xe7ionalization') == 'int_rna_ionalization'
+        # The rhs is intentionally native strings
+        assert scribify(b'stream_service_errors') == str('stream_service_errors')
+        assert scribify("this is a test") == str('this_is_a_test')
+        assert scribify("this\0is a-test\n\n") == str('this_is_a-test__')
+        assert scribify(u'int\xe9rna\xe7ionalization') == str('int_rna_ionalization')
 
 
 class TestStdoutLogger(object):


### PR DESCRIPTION
- Renamed 2 tests so they actually run under pytest (lol)
- Fixed the port race under test
- Fix `scribify` function
