### PR TITLE
Log the directory when clog is unable to open the stream for writing.

### DIFF
--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -252,7 +252,13 @@ class FileLogger(object):
                 # open file in log directory with name STREAM.log, in unbuffered mode
                 self.stream_files[stream] = self._create_file(stream)
             except IOError:
-                print("Unable to open file for stream %s" % (stream,), file=sys.stderr)
+                print(
+                    "Unable to open file for stream {stream} in directory {directory}".format(
+                        stream=stream,
+                        directory=config.log_dir,
+                    ),
+                    file=sys.stderr,
+                )
                 raise
 
         if isinstance(line, str):

--- a/tests/test_clog.py
+++ b/tests/test_clog.py
@@ -91,6 +91,19 @@ class TestGZipFileLogger(object):
             content = self._open_and_remove(log_filename)
             assert content == complete_line
 
+    def test_cant_open_stream(self, capsys):
+        log_dir = os.path.join(self.log_dir, 'non_existent_directory')
+        with staticconf.testing.MockConfiguration(log_dir=log_dir, namespace='clog'):
+            logger = GZipFileLogger()
+            stream = 'first'
+            with pytest.raises(IOError):
+                logger.log_line(stream, first_line)
+
+            stdout, stderr = capsys.readouterr()
+            assert stderr == 'Unable to open file for stream first in directory {0}\n'.format(
+                log_dir
+            )
+
 
 class MyError(Exception):
     pass


### PR DESCRIPTION
I ran into an issue where the logs directory didn't exist in a docker container. If I had immediately known which directory it was trying to write to, it would have saved me a lot of debugging time. Therefore, I decided to add the directory to the error message.

This also adds test coverage for that error case.