### PR TITLE
Fix bug where ScribeHandler errors and fails to log if retry_interval is not set

### DIFF
--- a/clog/handlers.py
+++ b/clog/handlers.py
@@ -70,9 +70,10 @@ class ScribeHandler(logging.Handler):
     :param host: hostname of scribe server
     :param port: port number of scribe server
     :param stream: name of the scribe stream logs will be sent to
+    :param retry_interval: default 0, number of seconds to wait between retries
     """
 
-    def __init__(self, host, port, stream, retry_interval=None):
+    def __init__(self, host, port, stream, retry_interval=0):
         logging.Handler.__init__(self)
         self.stream = stream
         self.logger = ScribeLogger(host, port, retry_interval)

--- a/clog/handlers.py
+++ b/clog/handlers.py
@@ -64,7 +64,7 @@ class ScribeHandler(logging.Handler):
 
         import clog.handlers, logging
         log = logging.getLogger(name)
-        log.addHandler(clog.handlers.ScribeHandler('localhost', 3600, 10))
+        log.addHandler(clog.handlers.ScribeHandler('localhost', 3600, 'stream', retry_interval=3))
 
 
     :param host: hostname of scribe server

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -31,6 +31,7 @@ class TestScribeHandler(object):
     def test_init(self):
         assert self.handler.stream == 'test_stream'
         assert self.handler.logger.__class__ == loggers.ScribeLogger
+        assert self.handler.logger.retry_interval is not None
 
     def test_emit_exception(self):
         self.handler.logger.log_line = mock.Mock()


### PR DESCRIPTION
Example traceback when I initialized ScribeHandler without a retry_interval set:
```
--- Logging error ---
Traceback (most recent call last):
  File "/nail/home/kkelly/y/scarab_scribe_extension/venv/lib/python3.4/site-packages/clog/handlers.py", line 83, in emit
    self.logger.log_line(self.stream, msg)
  File "/nail/home/kkelly/y/scarab_scribe_extension/venv/lib/python3.4/site-packages/clog/loggers.py", line 209, in log_line
    self._log_line_no_size_limit(stream, line)
  File "/nail/home/kkelly/y/scarab_scribe_extension/venv/lib/python3.4/site-packages/clog/loggers.py", line 177, in _log_line_no_size_limit
    self._maybe_reconnect()
  File "/nail/home/kkelly/y/scarab_scribe_extension/venv/lib/python3.4/site-packages/clog/loggers.py", line 160, in _maybe_reconnect
    if (now - self.last_connect_time) > self.retry_interval:
TypeError: unorderable types: float() > NoneType()
```

Included a new assert to make sure ScribeLogger's `retry_interval` is not None when setup by ScribeHandler.

EDIT: Seems to be a new failure mode in python3+. Defaulting to 0 should give the desired behavior in py2 and py3, though.