### PR TITLE
Switch from future to six

### DIFF
--- a/clog/__init__.py
+++ b/clog/__init__.py
@@ -42,7 +42,6 @@ from a server.
 """
 
 from __future__ import absolute_import
-from builtins import map
 
 from clog.loggers import ScribeLogger, ScribeIsNotForkSafeError
 from clog.global_state import log_line, reset_default_loggers

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -34,8 +34,6 @@ import simplejson as json
 import pkg_resources
 
 import thriftpy
-from builtins import object
-from builtins import str
 
 
 from clog import config

--- a/clog/readers.py
+++ b/clog/readers.py
@@ -16,9 +16,6 @@
 Classes which read log data from scribe.
 """
 from __future__ import print_function
-from builtins import object
-from future import standard_library
-standard_library.install_aliases()
 
 from clog.scribe_net import ScribeS3, ScribeReader
 

--- a/clog/utils.py
+++ b/clog/utils.py
@@ -16,7 +16,15 @@ import bz2
 import gzip
 import re
 
-from future.utils import text_to_native_str
+import six
+
+
+if six.PY3:  # pragma: no cover (PY3)
+    def text_to_native_str(s):
+        return s
+else:  # pragma: no cover (PY2)
+    def text_to_native_str(s):
+        return s.encode('UTF-8')
 
 
 DISALLOWED_STREAM_CHARACTERS_RE = re.compile(u'[^-_a-zA-Z0-9]')

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ setup(
     },
     install_requires=[
         'boto>=2.0.0',
-        'future>=0.14.0',
         'thriftpy',
         'PyStaticConfiguration >= 0.8',
         'simplejson',
+        'six>=1.4.0',
     ]
 )

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import print_function
-from builtins import range
 import datetime
 import os.path
 import shutil

--- a/tests/test_tailer.py
+++ b/tests/test_tailer.py
@@ -12,9 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from builtins import range
-from builtins import str
-
 import codecs
 import itertools
 import os
@@ -25,6 +22,7 @@ import time
 
 import pytest
 import mock
+import six
 
 from clog import readers, loggers
 from testing import sandbox
@@ -88,7 +86,7 @@ class TestStreamTailerAcceptance(object):
 
     def test_unicode(self):
         eszett_str = get_nonce_str() + " " + u'\xdf'
-        assert isinstance(eszett_str, str)
+        assert isinstance(eszett_str, six.text_type)
 
         for _ in range(10):
             self.logger.log_line(self.stream, eszett_str)


### PR DESCRIPTION
CC @bukzor

We've identified future as a problematic library when working in a python2 space.  It does the following things which are "useful" but often cause problems for code which does not expect them (or already correctly handles python2+3):
- Introduces two new string types `newstr` and `newbytes` which act like the python3 equivalents.  Libraries (including the stdlib (especially urlparse / urllib)) will happily attempt to `str(...)` these objects.  This will end up converting `newbytes` to `"b'foo'"` which is somewhat problematic
- These types can leak out of libraries which correctly handle them into libraries which do not (and do not expect them!).
- It installs aliases to the new stdlib libraries in the default import space (making things like `import configparser` (in python2 it's `ConfigParser`) *just work*).  This sounds like a great idea but cause some problems in some cases:
    - libraries which use this as a means for detecting py2 / py3 (admittedly a bug in those libraries, but it happens!)
    - Breaks virtualenv when trying to make python3 virtualenvs: https://github.com/PythonCharmers/python-future/issues/148

I've opted to switch to the non-intrusive `six` library for `yelp-clog`