### PR TITLE
Add 'binary' flag to file logger to allow unbuffered file writing

### DIFF
--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -263,13 +263,14 @@ class FileLogger(object):
         if isinstance(line, six.text_type):
             line = line.encode('UTF-8')
         self.stream_files[stream].write(line + b'\n')
+        self.stream_files[stream].flush()
 
     def close(self):
         for name in self.stream_files:
             self.stream_files[name].close()
 
     def _create_file(self, stream):
-        return open(os.path.join(config.log_dir, stream + '.log'), 'ab', 0)
+        return open(os.path.join(config.log_dir, stream + '.log'), 'a', 0)
 
 
 class GZipFileLogger(FileLogger):

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -269,7 +269,7 @@ class FileLogger(object):
             self.stream_files[name].close()
 
     def _create_file(self, stream):
-        return open(os.path.join(config.log_dir, stream + '.log'), 'a', 0)
+        return open(os.path.join(config.log_dir, stream + '.log'), 'ab', 0)
 
 
 class GZipFileLogger(FileLogger):


### PR DESCRIPTION
Unbuffered file writing on non-binary files doesn't work in py3, which means local file logging won't work on py3 services. Big pain.