### PR TITLE
Make sure that we can create files using the FileLogger in python3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build/
 *.pyc
 *.swp
 dist/
+.cache
 .idea
 .tox
 yelp_clog.egg-info/

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -269,7 +269,7 @@ class FileLogger(object):
             self.stream_files[name].close()
 
     def _create_file(self, stream):
-        return open(os.path.join(config.log_dir, stream + '.log'), 'a', 0)
+        return open(os.path.join(config.log_dir, stream + '.log'), 'ab', 0)
 
 
 class GZipFileLogger(FileLogger):

--- a/tests/test_clog.py
+++ b/tests/test_clog.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import unicode_literals
+
 from datetime import date, timedelta
 import gzip
 import logging
@@ -21,11 +23,12 @@ import tempfile
 
 import mock
 import pytest
+import six
 import staticconf.testing
 
 from clog.handlers import CLogHandler, DEFAULT_FORMAT
 from clog.handlers import get_scribed_logger
-from clog.loggers import GZipFileLogger, MockLogger, StdoutLogger
+from clog.loggers import FileLogger, GZipFileLogger, MockLogger, StdoutLogger
 from clog.utils import scribify
 
 
@@ -34,16 +37,17 @@ second_line = 'Second Line.'
 complete_line = '%s\n%s\n' % (first_line, second_line)
 
 
-class TestGZipFileLogger(object):
+@pytest.yield_fixture
+def log_directory():
+    log_dir = tempfile.mkdtemp()
+    with staticconf.testing.MockConfiguration(
+        log_dir=log_dir, namespace='clog',
+    ):
+        yield log_dir
+    shutil.rmtree(log_dir)
 
-    @pytest.yield_fixture(autouse=True)
-    def setup_log_dir(self):
-        self.log_dir = tempfile.mkdtemp()
-        with staticconf.testing.MockConfiguration(
-            log_dir=self.log_dir, namespace='clog',
-        ):
-            yield
-        shutil.rmtree(self.log_dir)
+
+class TestGZipFileLogger(object):
 
     def _open_and_remove(self, filename):
         gz_fh = gzip.open(filename)
@@ -52,7 +56,7 @@ class TestGZipFileLogger(object):
         os.remove(filename)
         return content.decode('utf8')
 
-    def test_no_day(self):
+    def test_no_day(self, log_directory):
         logger = GZipFileLogger()
         stream = 'first'
         logger.log_line(stream, first_line)
@@ -63,7 +67,7 @@ class TestGZipFileLogger(object):
         content = self._open_and_remove(log_filename)
         assert content == complete_line
 
-    def test_single_day(self):
+    def test_single_day(self, log_directory):
         stream = 'second'
         day = date.today()
         logger = GZipFileLogger(day=day)
@@ -75,7 +79,7 @@ class TestGZipFileLogger(object):
         content = self._open_and_remove(log_filename)
         assert content == complete_line
 
-    def test_multi_day(self):
+    def test_multi_day(self, log_directory):
         stream = 'multi'
         first_day = date.today()
         second_day = date.today() + timedelta(days=1)
@@ -91,10 +95,36 @@ class TestGZipFileLogger(object):
             content = self._open_and_remove(log_filename)
             assert content == complete_line
 
-    def test_cant_open_stream(self, capsys):
-        log_dir = os.path.join(self.log_dir, 'non_existent_directory')
+
+class TestFileLogger(object):
+
+    def _open_and_remove(self, filename):
+        with open(filename) as f:
+            contents = f.read()
+
+        os.remove(filename)
+        if isinstance(contents, six.binary_type):
+            return contents.decode('utf-8')
+        else:
+            return contents
+
+    @pytest.mark.parametrize('line1, expected_output', [
+        ('hello', 'hello\nworld\n'),
+        ('☃', '☃\nworld\n'),
+    ])
+    def test_log_line(self, log_directory, line1, expected_output):
+        logger = FileLogger()
+        stream = 'file_logger_stream'
+        logger.log_line(stream, line1)
+        logger.log_line(stream, 'world')
+        logger.close()
+
+        assert self._open_and_remove(logger.stream_files[stream].name) == expected_output
+
+    def test_cant_open_stream(self, log_directory, capsys):
+        log_dir = os.path.join(log_directory, 'non_existent_directory')
         with staticconf.testing.MockConfiguration(log_dir=log_dir, namespace='clog'):
-            logger = GZipFileLogger()
+            logger = FileLogger()
             stream = 'first'
             with pytest.raises(IOError):
                 logger.log_line(stream, first_line)


### PR DESCRIPTION
Before this change:

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/code/biz_messaging/kew_workers/email_reply_processor_worker.py", line 56, in <module>
    EmailReplyProcessor().start()
  File "/code/virtualenv_run/lib/python3.5/site-packages/yelp_batch/batch.py", line 559, in start
    self._log_shutdown(exit_code)
  File "/code/virtualenv_run/lib/python3.5/site-packages/yelp_batch/batch.py", line 602, in _log_shutdown
    self.log.info(shutdown_msg)
  File "/usr/lib/python3.5/logging/__init__.py", line 1279, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/lib/python3.5/logging/__init__.py", line 1415, in _log
    self.handle(record)
  File "/usr/lib/python3.5/logging/__init__.py", line 1425, in handle
    self.callHandlers(record)
  File "/usr/lib/python3.5/logging/__init__.py", line 1487, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python3.5/logging/__init__.py", line 855, in handle
    self.emit(record)
  File "/code/virtualenv_run/lib/python3.5/site-packages/clog/handlers.py", line 52, in emit
    self.logger.log_line(self.stream, msg)
  File "/code/virtualenv_run/lib/python3.5/site-packages/clog/global_state.py", line 79, in log_line
    logger.log_line(stream, line)
  File "/code/virtualenv_run/lib/python3.5/site-packages/clog/loggers.py", line 252, in log_line
    self.stream_files[stream] = self._create_file(stream)
  File "/code/virtualenv_run/lib/python3.5/site-packages/clog/loggers.py", line 266, in _create_file
    return open(os.path.join(config.log_dir, stream + '.log'), 'a', 0)
ValueError: can't have unbuffered text I/O
```

In python2, we open streams by default in byte mode. Therefore, to preserve compatibility, we now add the 'b' flag when opening those files.