### PR TITLE
Add region and superregion

### DIFF
--- a/clog/readers.py
+++ b/clog/readers.py
@@ -226,6 +226,10 @@ class StreamTailer(object):
     :type  host: string
     :param port: the port to connect to
     :type  port:
+    :param region: log source region, override superregion
+    :type  region: string
+    :param superregion: log source super region
+    :type  superregion: string
     :param bufsize: the number of bytes to buffer
     :param automagic_recovery: continue to retry connection forever
     :type  automagic_recovery: bool
@@ -251,6 +255,8 @@ class StreamTailer(object):
                  stream,
                  host=None,
                  port=None,
+                 region=None,
+                 superregion=None,
                  bufsize=4096,
                  automagic_recovery=True,
                  add_newlines=True,
@@ -270,6 +276,8 @@ class StreamTailer(object):
             self.host = host
 
         self.port = port
+        self.region = region
+        self.superregion = superregion
         self.bufsize = bufsize
         self._stream = stream
         self._automagic_recovery = automagic_recovery
@@ -284,6 +292,10 @@ class StreamTailer(object):
                 raise Exception("Last n lines can be only used with new kafka tailer")
             self._stream = stream + " " + str(lines)
             self._automagic_recovery = False
+        if self.region:
+            self._stream += " region=%s" % self.region
+        elif self.superregion:
+            self._stream += " superregion=%s" % self.superregion
         signal.signal(signal.SIGTERM, self.handle_sigterm)
 
     def handle_sigterm(self, signum, frame):

--- a/tests/test_tailer.py
+++ b/tests/test_tailer.py
@@ -96,49 +96,35 @@ class TestStreamTailerAcceptance(object):
         lines = wait_on_lines(self.tailer, 1)
         assert lines == [eszett_str_utf8]
 
-    def test_tail_lines(self):
-        tailer = readers.StreamTailer(
-                self.stream,
-                add_newlines=False,
-                automagic_recovery=False,
-                timeout=0.2,
-                host='localhost',
-                port=1234,
-                use_kafka=True,
-                lines=2)
-        assert tailer._stream == self.stream + ' 2'
-
-    def test_tail_lines_with_one_option(self):
-        tailer = readers.StreamTailer(
-                self.stream,
-                add_newlines=False,
-                automagic_recovery=False,
-                timeout=0.2,
-                host='localhost',
-                port=1234,
-                use_kafka=True,
-                lines=2,
-                protocol_opts={'opt1': 'value1'})
-        assert tailer._stream == self.stream + ' 2 opt1=value1'
-
-    def test_tail_lines_with_multiple_options(self):
-        tailer = readers.StreamTailer(
-                self.stream,
-                add_newlines=False,
-                automagic_recovery=False,
-                timeout=0.2,
-                host='localhost',
-                port=1234,
-                use_kafka=True,
-                lines=2,
-                protocol_opts={'opt1': 'value1', 'opt2': 'value2'})
-        assert tailer._stream.startswith(self.stream + ' 2')
-        assert ' opt1=value1' in tailer._stream
-        assert ' opt2=value2' in tailer._stream
-
 def test_find_tail_host():
     assert readers.find_tail_host('fakehost') == 'fakehost'
 
+def test_construct_conn_msg_without_lines():
+    conn_msg = readers.construct_conn_msg("streamA")
+    assert conn_msg == 'streamA\n'
+
+def test_construct_conn_msg_with_lines():
+    conn_msg = readers.construct_conn_msg('streamA', lines=2)
+    assert conn_msg == 'streamA 2\n'
+
+def test_tail_lines_with_options():
+    conn_msg = readers.construct_conn_msg(
+            'streamA',
+            protocol_opts={'opt1': 'value1', 'opt2': 'value2'})
+    assert conn_msg.startswith('streamA opt')
+    assert conn_msg.endswith('\n')
+    assert ' opt1=value1' in conn_msg
+    assert ' opt2=value2' in conn_msg
+
+def test_tail_lines_with_lines_and_options():
+    conn_msg = readers.construct_conn_msg(
+            'streamA',
+            lines=10,
+            protocol_opts={'opt1': 'value1', 'opt2': 'value2'})
+    assert conn_msg.startswith('streamA 10')
+    assert conn_msg.endswith('\n')
+    assert ' opt1=value1' in conn_msg
+    assert ' opt2=value2' in conn_msg
 
 def get_settings_side_effect(*args, **kwargs):
     if args[0] == 'DEFAULT_SCRIBE_TAIL_HOST':

--- a/tests/test_tailer.py
+++ b/tests/test_tailer.py
@@ -115,6 +115,7 @@ def test_tail_lines_with_options():
     assert conn_msg.endswith('\n')
     assert ' opt1=value1' in conn_msg
     assert ' opt2=value2' in conn_msg
+    assert len(conn_msg) == 32
 
 def test_tail_lines_with_lines_and_options():
     conn_msg = readers.construct_conn_msg(
@@ -125,6 +126,7 @@ def test_tail_lines_with_lines_and_options():
     assert conn_msg.endswith('\n')
     assert ' opt1=value1' in conn_msg
     assert ' opt2=value2' in conn_msg
+    assert len(conn_msg) == 35
 
 def get_settings_side_effect(*args, **kwargs):
     if args[0] == 'DEFAULT_SCRIBE_TAIL_HOST':

--- a/tests/test_tailer.py
+++ b/tests/test_tailer.py
@@ -108,7 +108,7 @@ class TestStreamTailerAcceptance(object):
                 lines=2)
         assert tailer._stream == self.stream + ' 2'
 
-    def test_tail_lines_with_region(self):
+    def test_tail_lines_with_one_option(self):
         tailer = readers.StreamTailer(
                 self.stream,
                 add_newlines=False,
@@ -118,10 +118,10 @@ class TestStreamTailerAcceptance(object):
                 port=1234,
                 use_kafka=True,
                 lines=2,
-                region='regionA')
-        assert tailer._stream == self.stream + ' 2 region=regionA'
+                protocol_opts={'opt1': 'value1'})
+        assert tailer._stream == self.stream + ' 2 opt1=value1'
 
-    def test_tail_lines_with_superregion(self):
+    def test_tail_lines_with_multiple_options(self):
         tailer = readers.StreamTailer(
                 self.stream,
                 add_newlines=False,
@@ -131,22 +131,10 @@ class TestStreamTailerAcceptance(object):
                 port=1234,
                 use_kafka=True,
                 lines=2,
-                superregion='superregionB')
-        assert tailer._stream == self.stream + ' 2 superregion=superregionB'
-
-    def test_tail_lines_with_both_region_and_superregion(self):
-        tailer = readers.StreamTailer(
-                self.stream,
-                add_newlines=False,
-                automagic_recovery=False,
-                timeout=0.2,
-                host='localhost',
-                port=1234,
-                use_kafka=True,
-                lines=2,
-                region='regionA',
-                superregion='superregionB')
-        assert tailer._stream == self.stream + ' 2 region=regionA'
+                protocol_opts={'opt1': 'value1', 'opt2': 'value2'})
+        assert tailer._stream.startswith(self.stream + ' 2')
+        assert ' opt1=value1' in tailer._stream
+        assert ' opt2=value2' in tailer._stream
 
 def test_find_tail_host():
     assert readers.find_tail_host('fakehost') == 'fakehost'

--- a/tests/test_tailer.py
+++ b/tests/test_tailer.py
@@ -108,6 +108,45 @@ class TestStreamTailerAcceptance(object):
                 lines=2)
         assert tailer._stream == self.stream + ' 2'
 
+    def test_tail_lines_with_region(self):
+        tailer = readers.StreamTailer(
+                self.stream,
+                add_newlines=False,
+                automagic_recovery=False,
+                timeout=0.2,
+                host='localhost',
+                port=1234,
+                use_kafka=True,
+                lines=2,
+                region='regionA')
+        assert tailer._stream == self.stream + ' 2 region=regionA'
+
+    def test_tail_lines_with_superregion(self):
+        tailer = readers.StreamTailer(
+                self.stream,
+                add_newlines=False,
+                automagic_recovery=False,
+                timeout=0.2,
+                host='localhost',
+                port=1234,
+                use_kafka=True,
+                lines=2,
+                superregion='superregionB')
+        assert tailer._stream == self.stream + ' 2 superregion=superregionB'
+
+    def test_tail_lines_with_both_region_and_superregion(self):
+        tailer = readers.StreamTailer(
+                self.stream,
+                add_newlines=False,
+                automagic_recovery=False,
+                timeout=0.2,
+                host='localhost',
+                port=1234,
+                use_kafka=True,
+                lines=2,
+                region='regionA',
+                superregion='superregionB')
+        assert tailer._stream == self.stream + ' 2 region=regionA'
 
 def test_find_tail_host():
     assert readers.find_tail_host('fakehost') == 'fakehost'


### PR DESCRIPTION
As we described in CEP611, yelp_clog readers need to pass region or superregion to scribe tailer service so that it can tail the correct kafka cluster.
This change is backwards compatible since two new params are optional. For the old services or libs that depend on yelp_clog, they should continue to work.

make test passes locally.