### PR TITLE
Adding type checking within MockLoggers log_line function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 
 Release Notes
 =============
+2.6.1
+-----
+
+* Add type checking to ``MockLogger`` log_line function
+
 2.6.0
 -----
 

--- a/clog/__init__.py
+++ b/clog/__init__.py
@@ -53,5 +53,5 @@ _pyflakes_ignore = [
     reset_default_loggers,
 ]
 
-version_info = 2, 6, 0
+version_info = 2, 6, 1
 __version__ = '.'.join(map(str, version_info))

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -303,7 +303,7 @@ class MockLogger(object):
         self.lines = {}
 
     def log_line(self, stream, line):
-        assert isinstance(line, six.text_type)
+        assert isinstance(line, (bytes, six.string_types))
         self.lines.setdefault(stream, []).append(line)
 
     def clear_lines(self, stream):

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -303,6 +303,7 @@ class MockLogger(object):
         self.lines = {}
 
     def log_line(self, stream, line):
+        assert isinstance(line, six.text_type)
         self.lines.setdefault(stream, []).append(line)
 
     def clear_lines(self, stream):

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -303,7 +303,8 @@ class MockLogger(object):
         self.lines = {}
 
     def log_line(self, stream, line):
-        assert isinstance(line, (bytes, six.string_types))
+        assert isinstance(stream, (bytes, six.text_type))
+        assert isinstance(line, (bytes, six.text_type))
         self.lines.setdefault(stream, []).append(line)
 
     def clear_lines(self, stream):

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -303,8 +303,8 @@ class MockLogger(object):
         self.lines = {}
 
     def log_line(self, stream, line):
-        assert isinstance(stream, (bytes, six.text_type))
-        assert isinstance(line, (bytes, six.text_type))
+        assert isinstance(stream, (bytes, six.text_type)), type(stream)
+        assert isinstance(line, (bytes, six.text_type)), type(line)
         self.lines.setdefault(stream, []).append(line)
 
     def clear_lines(self, stream):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 
 setup(
     name='yelp-clog',
-    version='2.6.0',
+    version='2.6.1',
     description='A package which provides logging and reading from scribe.',
     author='Yelp Infra Team',
     author_email='infra@yelp.com',


### PR DESCRIPTION
A quick assertion to make sure that people are only attempting to log strings/text, and that attempting to log other other types isn't eaten by the mock.