### PR TITLE
Add support for py36

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         'boto>=2.0.0',
         'thriftpy',
-        'PyStaticConfiguration >= 0.8',
+        'PyStaticConfiguration >= 0.10.3',
         'simplejson',
         'six>=1.4.0',
     ],
@@ -36,6 +36,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # NOTE: pypy is known to work, but we don't have it installed...  yet.
-envlist = py27,py34,py35
+envlist = py27,py34,py35,py36
 
 [testenv]
 deps =


### PR DESCRIPTION
Looks like python3.6 changed the way os.path.join works:

```python
# Python 3.5
ipdb> type(clog_config.log_dir)
<class 'staticconf.proxy.ValueProxy'>
ipdb> os.path.join(clog_config.log_dir, 'hi')
'/nail/tmp/hi'

# Python 3.6
(Pdb) type(clog_config.log_dir)
<class 'staticconf.proxy.ValueProxy'>
(Pdb) os.path.join(clog_config.log_dir, 'hi')
*** TypeError: expected str, bytes or os.PathLike object, not ValueProxy
```

A bunch of os methods now only accept 'path-like objects' (https://docs.python.org/3/glossary.html#term-path-like-object) where they seemed previously fine with ValueProxies from staticconf.

Added a tox env for py36 and fixed the two failures here. I don't know if there are other more subtle problems in py36: happy to expand this PR.