### PR TITLE
Add uwsgi_plugin module

### DIFF
--- a/clog/__init__.py
+++ b/clog/__init__.py
@@ -46,9 +46,17 @@ from __future__ import absolute_import
 from clog.loggers import ScribeLogger, ScribeIsNotForkSafeError
 from clog.global_state import log_line, reset_default_loggers
 
+try:
+    from clog.uwsgi_plugin import uwsgi_patch_global_state, uwsgi_log_line
+    uwsgi_plugin_enabled = True
+except ImportError:
+    uwsgi_plugin_enabled = False
+    pass
+
 _pyflakes_ignore = [
     ScribeLogger,
     ScribeIsNotForkSafeError,
     log_line,
     reset_default_loggers,
+    uwsgi_patch_global_state,
 ]

--- a/clog/__init__.py
+++ b/clog/__init__.py
@@ -58,6 +58,8 @@ _pyflakes_ignore = [
     ScribeIsNotForkSafeError,
     log_line,
     reset_default_loggers,
+] + ([
     uwsgi_patch_global_state,
     uwsgi_log_line,
-]
+] if uwsgi_plugin_enabled else [])
+

--- a/clog/__init__.py
+++ b/clog/__init__.py
@@ -46,11 +46,11 @@ from __future__ import absolute_import
 from clog.loggers import ScribeLogger, ScribeIsNotForkSafeError
 from clog.global_state import log_line, reset_default_loggers
 
+uwsgi_plugin_enabled = False
 try:
     from clog.uwsgi_plugin import uwsgi_patch_global_state, uwsgi_log_line
     uwsgi_plugin_enabled = True
 except ImportError:
-    uwsgi_plugin_enabled = False
     pass
 
 _pyflakes_ignore = [
@@ -59,4 +59,5 @@ _pyflakes_ignore = [
     log_line,
     reset_default_loggers,
     uwsgi_patch_global_state,
+    uwsgi_log_line,
 ]

--- a/clog/uwsgi_plugin.py
+++ b/clog/uwsgi_plugin.py
@@ -77,6 +77,11 @@ def uwsgi_patch_global_state():
 
 setattr(clog.handlers, 'UwsgiHandler', UwsgiHandler)
 _orig_log_line = clog.global_state.log_line
+# It's vital that no other module override this hook after we have done so.
+# This is an unfortunate consequence of the uwsgi_python plugin but the
+# hook implementation isn't naturally exstensible - we're managing here by
+# making assumptions about the environment, one of which is that uwsgidecorators
+# is the only other module installing to this hook.
 uwsgi.mule_msg_hook = _plugin_mule_msg_shim
 # See https://github.com/unbit/uwsgi/pull/1487
 max_recv_size = getattr(uwsgi, 'mule_msg_recv_size', lambda: 65536)()

--- a/clog/uwsgi_plugin.py
+++ b/clog/uwsgi_plugin.py
@@ -33,6 +33,8 @@ class UwsgiHandler(logging.Handler):
         try:
             msg = self.format(record)
             _mule_msg(self.stream, msg, mule=self.mule)
+        except Exception:
+            raise
         except:
             self.handleError(record)
 

--- a/clog/uwsgi_plugin.py
+++ b/clog/uwsgi_plugin.py
@@ -1,0 +1,59 @@
+import uwsgi
+import uwsgidecorators
+import logging
+import clog
+import clog.global_state
+import clog.handlers
+import functools
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+
+def _mule_msg(*args, **kwargs):
+    mule = kwargs.pop('mule', 1)
+    func = kwargs.pop('func', 'log_line')
+    data = pickle.dumps({
+        'service': 'uwsgi_mulefunc',
+        'func': func,
+        'args': args,
+        'kwargs': kwargs,
+    })
+    uwsgi.mule_msg(data, mule)
+
+
+class UwsgiHandler(logging.Handler):
+
+    def __init__(self, stream, mule=1):
+        logging.Handler.__init__(self)
+        self.stream = stream
+        self.mule = mule
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            _mule_msg(self.stream, msg, mule=self.mule, func='log_line')
+        except:
+            self.handleError(record)
+
+
+def uwsgi_patch_global_state(func='log_line', mule=1):
+    map(
+        lambda x: setattr(x, func, functools.partial(_mule_msg, func=func, mule=mule)),
+        (clog, clog.global_state)
+    )
+
+# TODO: Patch upstream uwsgi to return success on the pipe write so
+# we can optionally default to sync log_line
+def uwsgi_log_line(stream, line, mule=1):
+    _mule_msg(stream, line, mule=mule, func='log_line')
+
+
+# Couple setup tasks at import:
+# 1. Register 'log_line' in all mules for dispatch handling on the mule side
+# 2. Insert 'UwsgiHandler' into the clog.handlers module for seamless usage
+
+uwsgidecorators.mule_functions['log_line'] = clog.global_state.log_line
+setattr(clog.handlers, 'UwsgiHandler', UwsgiHandler)

--- a/clog/uwsgi_plugin.py
+++ b/clog/uwsgi_plugin.py
@@ -37,16 +37,17 @@ class UwsgiHandler(logging.Handler):
             self.handleError(record)
 
 
-def uwsgi_patch_global_state(mule=1):
-    map(
-        lambda x: setattr(x, 'log_line', _mule_msg),
-        (clog, clog.global_state)
-    )
-
 # TODO: Patch upstream uwsgi to return success on the pipe write so
 # we can optionally default to sync log_line
 def uwsgi_log_line(stream, line, mule=1):
     _mule_msg(stream, line, mule=mule)
+
+
+def uwsgi_patch_global_state():
+    map(
+        lambda x: setattr(x, 'log_line', uwsgi_log_line),
+        (clog, clog.global_state)
+    )
 
 
 # Couple setup tasks at import:

--- a/clog/uwsgi_plugin.py
+++ b/clog/uwsgi_plugin.py
@@ -4,11 +4,7 @@ import logging
 import clog
 import clog.global_state
 import clog.handlers
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import six.moves.cPickle as pickle
 
 
 def _mule_msg(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'six>=1.4.0',
     ],
     extras_require={
-        'uwsgi': ['uWSGI>=2.0.14'],
+        'uwsgi': ['uWSGI>2.0.14'],
     },
     classifiers=[
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'six>=1.4.0',
     ],
     extras_require={
-        'uwsgi_offload': ['uWSGI>=2.0.14.0.post3'],
+        'uwsgi': ['uWSGI>=2.0.14'],
     },
     classifiers=[
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ setup(
         'simplejson',
         'six>=1.4.0',
     ],
+    extras_require={
+        'uwsgi_offload': ['uWSGI>=2.0.14.0.post3'],
+    },
     classifiers=[
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'six>=1.4.0',
     ],
     extras_require={
-        'uwsgi': ['uWSGI>2.0.14'],
+        'uwsgi': ['uWSGI'],
     },
     classifiers=[
         'Programming Language :: Python :: 2',


### PR DESCRIPTION
This PR introduces a uwsgi_plugin which adds opt-in functionality for clogging from mule processes, which brief benchmarking shows a 10x speedup in the critical path. The module is tentatively loaded at import time and, if in a uwsgi environment, will configure the mule dispatcher to have references to the `clog.global_state.log_line` function. Then any worker may call `clog.uwsgi_log_line` to dispatch a logging request to a mule. 

Alternatively the user may call `clog.uwsgi_patch_global_state` to monkey-patch the global state logger to dispatch to mules - in this vein there is an associated yelp_servlib.clog_util change that will to this inside initialization based on a configuration option. 

Lastly there's a UwsgiHandler class which can be attached to any logger that will dispatch logging requests to mules. This is a bit unnecessary if global state is patches as the default CLogHandler uses the global state loggers, but if someone wanted finer grained handler control, well they can have it.

Potential Gotcha:
The uwsgi signal system uses pipes under the hood to transmit data to mules. If the pipe is full a `mule_msg` call will simply drop the message and an error will be printed to stderr about mule message buffer sizes. Unfortunately the core/mule.c function doesn't return a response code regarding whether the mule pipe write was successful so we cannot currently take action on a failure (e.g. just do a normal log). However I have a working change for this behavior in uwsgi and will make a PR to upstream soon, as well as the appropriate additions in another branch of yelp_clog. So once that's in place we will have a "attempt async, default sync" behavior to opt-in.