### PR TITLE
Add uwsgi_plugin clog message header

### DIFF
--- a/clog/uwsgi_plugin.py
+++ b/clog/uwsgi_plugin.py
@@ -8,8 +8,8 @@ import six
 from uwsgidecorators import mule_msg_dispatcher
 
 HEADER_TAG = b'clog'
-HEADER_SZ = len(HEADER_TAG) + 8  # +8 for two `struct` integers
 ENCODE_FMT = '{}sii'.format(len(HEADER_TAG))
+HEADER_SZ = struct.calcsize(ENCODE_FMT)
 
 
 def _encode_mule_msg(stream, line):

--- a/testing/sandbox.py
+++ b/testing/sandbox.py
@@ -18,6 +18,7 @@ import os
 import signal
 import socket
 import subprocess
+import sys
 import tempfile
 import textwrap
 import time
@@ -155,3 +156,26 @@ def tailer_sandbox(port, log_path):
     finally:
         os.kill(proc.pid, signal.SIGTERM)
         proc.wait()
+
+
+def install_fake_uwsgi():
+    # Install a fake uwsgi module into sys.modules
+    # with a few of the used methods defined
+    class uwsgi(object):
+        mule_msg_hook = None
+
+        @staticmethod
+        def mule_msg(message, mule=None):
+            pass
+
+        @staticmethod
+        def mule_msg_recv_size():
+            return 65536
+
+    class uwsgidecorators(object):
+        @staticmethod
+        def mule_msg_dispatcher(message):
+            pass
+
+    sys.modules['uwsgi'] = uwsgi
+    sys.modules['uwsgidecorators'] = uwsgidecorators

--- a/testing/sandbox.py
+++ b/testing/sandbox.py
@@ -18,7 +18,6 @@ import os
 import signal
 import socket
 import subprocess
-import sys
 import tempfile
 import textwrap
 import time

--- a/testing/sandbox.py
+++ b/testing/sandbox.py
@@ -156,26 +156,3 @@ def tailer_sandbox(port, log_path):
     finally:
         os.kill(proc.pid, signal.SIGTERM)
         proc.wait()
-
-
-def install_fake_uwsgi():
-    # Install a fake uwsgi module into sys.modules
-    # with a few of the used methods defined
-    class uwsgi(object):
-        mule_msg_hook = None
-
-        @staticmethod
-        def mule_msg(message, mule=None):
-            pass
-
-        @staticmethod
-        def mule_msg_recv_size():
-            return 65536
-
-    class uwsgidecorators(object):
-        @staticmethod
-        def mule_msg_dispatcher(message):
-            pass
-
-    sys.modules['uwsgi'] = uwsgi
-    sys.modules['uwsgidecorators'] = uwsgidecorators

--- a/tests/test_uwsgi_plugin.py
+++ b/tests/test_uwsgi_plugin.py
@@ -30,8 +30,14 @@ def uwsgi_plugin():
     import clog.uwsgi_plugin
 
     yield clog.uwsgi_plugin
+
     sys.modules.pop('uwsgi')
     sys.modules.pop('uwsgidecorators')
+    sys.modules.pop('clog.uwsgi_plugin')
+    del clog.handlers.UwsgiHandler
+
+    with pytest.raises(ImportError):
+        import clog.uwsgi_plugin
 
 
 @pytest.mark.usefixtures('uwsgi_plugin')

--- a/tests/test_uwsgi_plugin.py
+++ b/tests/test_uwsgi_plugin.py
@@ -43,29 +43,33 @@ def uwsgi_plugin():
 @pytest.mark.usefixtures('uwsgi_plugin')
 class TestUwsgiPlugin(object):
 
-    def test_uwsgi_handle_msg_header(self, uwsgi_plugin):
+    def test_uwsgi_handle_valid_msg(self, uwsgi_plugin):
+        message = ('this is a fake stream', 'this is a fake line!')
+        mule_msg_data = uwsgi_plugin._encode_mule_msg(*message)
+        with mock.patch.object(uwsgi_plugin, '_orig_log_line') as orig_line:
+            with mock.patch.object(uwsgi_plugin, 'mule_msg_dispatcher') as dispatcher:
+                uwsgi_plugin._plugin_mule_msg_shim(mule_msg_data)
+                orig_line.assert_called_with(*map(six.b, message))
+                assert not dispatcher.called
+
+    def test_uwsgi_handle_invalid_msg_pass_thru(self, uwsgi_plugin):
         message = ('this is a fake stream', 'this is a fake line!')
         pickle_data = pickle.dumps(message)
-        mule_msg_data = uwsgi_plugin._encode_mule_msg(*message)
         with mock.patch.object(uwsgi_plugin, '_orig_log_line') as orig_line:
             with mock.patch.object(uwsgi_plugin, 'mule_msg_dispatcher') as dispatcher:
                 uwsgi_plugin._plugin_mule_msg_shim(pickle_data)
                 dispatcher.assert_called_with(pickle_data)
-                uwsgi_plugin._plugin_mule_msg_shim(mule_msg_data)
-                orig_line.assert_called_with(*map(six.b, message))
-
+                assert not orig_line.called
 
     def test_uwsgi_default_over_max_size(self, uwsgi_plugin):
         big_string = 's' * 65536
         assert uwsgi_plugin._mule_msg('blah', big_string) == False
-
 
     def test_uwsgi_default_on_failed_mule_msg(self, uwsgi_plugin):
         with mock.patch.object(uwsgi_plugin, '_orig_log_line') as orig_line:
             with mock.patch.object(uwsgi_plugin, '_mule_msg', return_value=False):
                 uwsgi_plugin.uwsgi_log_line('blah', 'test_message')
                 orig_line.assert_called_with('blah', 'test_message')
-
 
     def test_uwsgi_mule_msg_header_apply(self, uwsgi_plugin):
         args = ('test_stream', 'test_line')
@@ -74,7 +78,6 @@ class TestUwsgiPlugin(object):
         with mock.patch('uwsgi.mule_msg') as mm:
             uwsgi_plugin._mule_msg(*args, **kwargs)
             mm.assert_called_with(expected_serialized)
-
 
     def test_uwsgi_mule_msg_header_apply_with_mule(self, uwsgi_plugin):
         args = ('test_stream', 'test_line')

--- a/tests/test_uwsgi_plugin.py
+++ b/tests/test_uwsgi_plugin.py
@@ -1,0 +1,62 @@
+from testing.sandbox import install_fake_uwsgi
+install_fake_uwsgi()
+
+
+import clog.uwsgi_plugin
+import marshal
+import mock
+import pickle
+
+
+def test_uwsgi_handle_msg_header():
+    clog_msg = (('abc', '123'), {})
+    pickle_data = pickle.dumps(clog_msg)
+    marshal_data = clog.uwsgi_plugin.MSG_HEADER + marshal.dumps(clog_msg)
+    with mock.patch('clog.uwsgi_plugin._orig_log_line') as orig_line:
+        with mock.patch('clog.uwsgi_plugin.mule_msg_dispatcher') as dispatcher:
+            clog.uwsgi_plugin._plugin_mule_msg_shim(pickle_data)
+            dispatcher.assert_called_with(pickle_data)
+            clog.uwsgi_plugin._plugin_mule_msg_shim(marshal_data)
+            orig_line.assert_called_with(*clog_msg[0], **clog_msg[1])
+
+
+def test_uwsgi_default_over_max_size():
+    big_string = 's' * 65536
+    assert clog.uwsgi_plugin._mule_msg('blah', big_string) == False
+
+
+def test_uwsgi_default_on_failed_mule_msg():
+    with mock.patch('clog.uwsgi_plugin._orig_log_line') as orig_line:
+        with mock.patch('clog.uwsgi_plugin._mule_msg', return_value=False):
+            clog.uwsgi_plugin.uwsgi_log_line('blah', 'test_message')
+            orig_line.assert_called_with('blah', 'test_message')
+
+
+def test_uwsgi_mule_msg_header_apply():
+    # for some reason python3 marshal serializes arguments
+    # differently when their handled via expansion/compaction
+    def build_serialized(*args, **kwargs):
+        kwargs.pop('mule', None)
+        return clog.uwsgi_plugin.MSG_HEADER + marshal.dumps((args, kwargs))
+
+    args = ('test_stream', 'test_line')
+    kwargs = {}
+    expected_serialized = build_serialized(*args, **kwargs)
+    with mock.patch('uwsgi.mule_msg') as mm:
+        clog.uwsgi_plugin._mule_msg(*args, **kwargs)
+        mm.assert_called_with(expected_serialized)
+
+
+def test_uwsgi_mule_msg_header_apply_with_mule():
+    # for some reason python3 marshal serializes arguments
+    # differently when their handled via expansion/compaction
+    def build_serialized(*args, **kwargs):
+        kwargs.pop('mule', None)
+        return clog.uwsgi_plugin.MSG_HEADER + marshal.dumps((args, kwargs))
+
+    args = ('test_stream', 'test_line')
+    kwargs = {'mule': 1}
+    expected_serialized = build_serialized(*args, **kwargs)
+    with mock.patch('uwsgi.mule_msg') as mm:
+        clog.uwsgi_plugin._mule_msg(*args, **kwargs)
+        mm.assert_called_with(expected_serialized, 1)

--- a/tests/test_uwsgi_plugin.py
+++ b/tests/test_uwsgi_plugin.py
@@ -7,7 +7,7 @@ import struct
 import sys
 
 MASTERPID = os.getpid()
-POLLUTE = os.environ.get('POLLUTE', False)
+POLLUTE = os.environ.get('POLLUTE')
 
 
 def install_fake_uwsgi():
@@ -30,8 +30,9 @@ def install_fake_uwsgi():
         def mule_msg_dispatcher(message):
             pass
 
-    sys.modules['uwsgi'] = uwsgi
-    sys.modules['uwsgidecorators'] = uwsgidecorators
+    if not 'uwsgi' in sys.modules:
+        sys.modules['uwsgi'] = uwsgi
+        sys.modules['uwsgidecorators'] = uwsgidecorators
 
 
 def run(target):

--- a/tests/test_uwsgi_plugin.py
+++ b/tests/test_uwsgi_plugin.py
@@ -1,62 +1,90 @@
-from testing.sandbox import install_fake_uwsgi
-install_fake_uwsgi()
-
-
-import clog.uwsgi_plugin
 import marshal
 import mock
 import pickle
+import pytest
+import sys
 
 
-def test_uwsgi_handle_msg_header():
-    clog_msg = (('abc', '123'), {})
-    pickle_data = pickle.dumps(clog_msg)
-    marshal_data = clog.uwsgi_plugin.MSG_HEADER + marshal.dumps(clog_msg)
-    with mock.patch('clog.uwsgi_plugin._orig_log_line') as orig_line:
-        with mock.patch('clog.uwsgi_plugin.mule_msg_dispatcher') as dispatcher:
-            clog.uwsgi_plugin._plugin_mule_msg_shim(pickle_data)
-            dispatcher.assert_called_with(pickle_data)
-            clog.uwsgi_plugin._plugin_mule_msg_shim(marshal_data)
-            orig_line.assert_called_with(*clog_msg[0], **clog_msg[1])
+@pytest.fixture(scope='module')
+def uwsgi_plugin():
+
+    class uwsgi(object):
+        mule_msg_hook = None
+
+        @staticmethod
+        def mule_msg(message, mule=None):
+            pass
+
+        @staticmethod
+        def mule_msg_recv_size():
+            return 65536
+
+    class uwsgidecorators(object):
+        @staticmethod
+        def mule_msg_dispatcher(message):
+            pass
+
+    sys.modules['uwsgi'] = uwsgi
+    sys.modules['uwsgidecorators'] = uwsgidecorators
+    import clog.uwsgi_plugin
+
+    yield clog.uwsgi_plugin
+    sys.modules.pop('uwsgi')
+    sys.modules.pop('uwsgidecorators')
 
 
-def test_uwsgi_default_over_max_size():
-    big_string = 's' * 65536
-    assert clog.uwsgi_plugin._mule_msg('blah', big_string) == False
+@pytest.mark.usefixtures('uwsgi_plugin')
+class TestUwsgiPlugin(object):
+
+    def test_uwsgi_handle_msg_header(self, uwsgi_plugin):
+        clog_msg = (('abc', '123'), {})
+        pickle_data = pickle.dumps(clog_msg)
+        marshal_data = uwsgi_plugin.MSG_HEADER + marshal.dumps(clog_msg)
+        with mock.patch.object(uwsgi_plugin, '_orig_log_line') as orig_line:
+            with mock.patch.object(uwsgi_plugin, 'mule_msg_dispatcher') as dispatcher:
+                uwsgi_plugin._plugin_mule_msg_shim(pickle_data)
+                dispatcher.assert_called_with(pickle_data)
+                uwsgi_plugin._plugin_mule_msg_shim(marshal_data)
+                orig_line.assert_called_with(*clog_msg[0], **clog_msg[1])
 
 
-def test_uwsgi_default_on_failed_mule_msg():
-    with mock.patch('clog.uwsgi_plugin._orig_log_line') as orig_line:
-        with mock.patch('clog.uwsgi_plugin._mule_msg', return_value=False):
-            clog.uwsgi_plugin.uwsgi_log_line('blah', 'test_message')
-            orig_line.assert_called_with('blah', 'test_message')
+    def test_uwsgi_default_over_max_size(self, uwsgi_plugin):
+        big_string = 's' * 65536
+        assert uwsgi_plugin._mule_msg('blah', big_string) == False
 
 
-def test_uwsgi_mule_msg_header_apply():
-    # for some reason python3 marshal serializes arguments
-    # differently when their handled via expansion/compaction
-    def build_serialized(*args, **kwargs):
-        kwargs.pop('mule', None)
-        return clog.uwsgi_plugin.MSG_HEADER + marshal.dumps((args, kwargs))
-
-    args = ('test_stream', 'test_line')
-    kwargs = {}
-    expected_serialized = build_serialized(*args, **kwargs)
-    with mock.patch('uwsgi.mule_msg') as mm:
-        clog.uwsgi_plugin._mule_msg(*args, **kwargs)
-        mm.assert_called_with(expected_serialized)
+    def test_uwsgi_default_on_failed_mule_msg(self, uwsgi_plugin):
+        with mock.patch.object(uwsgi_plugin, '_orig_log_line') as orig_line:
+            with mock.patch.object(uwsgi_plugin, '_mule_msg', return_value=False):
+                uwsgi_plugin.uwsgi_log_line('blah', 'test_message')
+                orig_line.assert_called_with('blah', 'test_message')
 
 
-def test_uwsgi_mule_msg_header_apply_with_mule():
-    # for some reason python3 marshal serializes arguments
-    # differently when their handled via expansion/compaction
-    def build_serialized(*args, **kwargs):
-        kwargs.pop('mule', None)
-        return clog.uwsgi_plugin.MSG_HEADER + marshal.dumps((args, kwargs))
+    def test_uwsgi_mule_msg_header_apply(self, uwsgi_plugin):
+        # for some reason python3 marshal serializes arguments
+        # differently when they're handled via expansion/compaction
+        def build_serialized(*args, **kwargs):
+            kwargs.pop('mule', None)
+            return uwsgi_plugin.MSG_HEADER + marshal.dumps((args, kwargs))
 
-    args = ('test_stream', 'test_line')
-    kwargs = {'mule': 1}
-    expected_serialized = build_serialized(*args, **kwargs)
-    with mock.patch('uwsgi.mule_msg') as mm:
-        clog.uwsgi_plugin._mule_msg(*args, **kwargs)
-        mm.assert_called_with(expected_serialized, 1)
+        args = ('test_stream', 'test_line')
+        kwargs = {}
+        expected_serialized = build_serialized(*args, **kwargs)
+        with mock.patch('uwsgi.mule_msg') as mm:
+            uwsgi_plugin._mule_msg(*args, **kwargs)
+            mm.assert_called_with(expected_serialized)
+
+
+    def test_uwsgi_mule_msg_header_apply_with_mule(self, uwsgi_plugin):
+        # for some reason python3 marshal serializes arguments
+        # differently when they're handled via expansion/compaction
+        def build_serialized(*args, **kwargs):
+            kwargs.pop('mule', None)
+            return uwsgi_plugin.MSG_HEADER + marshal.dumps((args, kwargs))
+
+        args = ('test_stream', 'test_line')
+        kwargs = {'mule': 1}
+        expected_serialized = build_serialized(*args, **kwargs)
+        with mock.patch('uwsgi.mule_msg') as mm:
+            uwsgi_plugin._mule_msg(*args, **kwargs)
+            mm.assert_called_with(expected_serialized, 1)

--- a/tests/test_uwsgi_plugin.py
+++ b/tests/test_uwsgi_plugin.py
@@ -87,14 +87,14 @@ class TestUwsgiPlugin(object):
             uwsgi_plugin._mule_msg(*args, **kwargs)
             mm.assert_called_with(expected_serialized, 1)
 
-    def test_decode_mule_msg_exc_tag(self, uwsgi_plugin):
+    def test_decode_mule_msg_tag_error(self, uwsgi_plugin):
         stream = b'test stream'
         line = b'test line'
         msg = struct.pack(uwsgi_plugin.ENCODE_FMT, b'blah', len(stream), len(line)) + stream + line
         with pytest.raises(ValueError):
             uwsgi_plugin._decode_mule_msg(msg)
 
-    def test_decode_mule_msg_exc_len(self, uwsgi_plugin):
+    def test_decode_mule_msg_len_error(self, uwsgi_plugin):
         stream = b'test_stream'
         line = b'test line'
         msg = struct.pack(uwsgi_plugin.ENCODE_FMT, uwsgi_plugin.HEADER_TAG, len(stream), len(line)-1) + stream + line

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist = py27,py34,py35,py36
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
+passenv = POLLUTE
 commands =
     python -m pytest -v {posargs:tests}
     pyflakes clog tests setup.py


### PR DESCRIPTION
It turns out attempting to marshal.loads data which isn't marshal
serialized can hang indefinitely. Let's not do that.