### PR TITLE
MONK-146 Add MetricsReporter class that can sample latency for clog.log_line calls

### DIFF
--- a/clog/config.py
+++ b/clog/config.py
@@ -108,6 +108,10 @@ use_kafka = clog_namespace.get_bool('use_kafka',
     default=False,
     help='If True, will tail from a stream via a service talking to Kafka')
 
+metrics_sample_rate = clog_namespace.get_int('metrics_sample_Rate',
+    default=0,
+    help='Number of messages to sample to emit one latency metric.')
+
 is_logging_configured = False
 
 

--- a/clog/config.py
+++ b/clog/config.py
@@ -108,7 +108,7 @@ use_kafka = clog_namespace.get_bool('use_kafka',
     default=False,
     help='If True, will tail from a stream via a service talking to Kafka')
 
-metrics_sample_rate = clog_namespace.get_int('metrics_sample_Rate',
+metrics_sample_rate = clog_namespace.get_int('metrics_sample_rate',
     default=0,
     help='Number of messages to sample to emit one latency metric.')
 

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -38,6 +38,7 @@ import thriftpy
 
 
 from clog import config
+from clog.metrics_reporter import MetricsReporter
 from clog.utils import scribify
 
 import thriftpy.transport.socket
@@ -148,6 +149,8 @@ class ScribeLogger(object):
         self.__lock = threading.RLock()
         self._birth_pid = os.getpid()
 
+        self.metrics = MetricsReporter()
+
     def _maybe_reconnect(self):
         """Try (re)connecting to the server if it's been long enough since our
         last attempt.
@@ -199,37 +202,39 @@ class ScribeLogger(object):
            If the line size is over 5 MB, a message consisting origin stream information
            will be recorded at WHO_CLOG_LARGE_LINE_STREAM (in json format).
         """
-        # log unicodes as their utf-8 encoded representation
-        if isinstance(line, six.text_type):
-            line = line.encode('UTF-8')
+        with self.metrics.sampled_request():
+            # log unicodes as their utf-8 encoded representation
+            if isinstance(line, six.text_type):
+                line = line.encode('UTF-8')
 
-        # check log line size
-        if len(line) <= WARNING_LINE_SIZE_IN_BYTES:
-            self._log_line_no_size_limit(stream, line)
-        elif len(line) <= MAX_LINE_SIZE_IN_BYTES:
-            self._log_line_no_size_limit(stream, line)
+            # check log line size
+            if len(line) <= WARNING_LINE_SIZE_IN_BYTES:
+                self._log_line_no_size_limit(stream, line)
+            elif len(line) <= MAX_LINE_SIZE_IN_BYTES:
+                self._log_line_no_size_limit(stream, line)
 
-            # log the origin of the stream with traceback to WHO_CLOG_LARGE_LINE_STREAM category
-            origin_info = {}
-            origin_info['stream'] = stream
-            origin_info['line_size'] = len(line)
-            origin_info['traceback'] = ''.join(traceback.format_stack())
-            log_line = json.dumps(origin_info).encode('UTF-8')
-            self._log_line_no_size_limit(WHO_CLOG_LARGE_LINE_STREAM, log_line)
-            self.report_status(
-                False,
-                'The log line size is larger than %r bytes (monitored in \'%s\')'
-                % (WARNING_LINE_SIZE_IN_BYTES, WHO_CLOG_LARGE_LINE_STREAM)
-            )
-        else:
-            # raise an exception if too large
-            self.report_status(
-                True,
-                'The log line is dropped (line size larger than %r bytes)'
-                % MAX_LINE_SIZE_IN_BYTES
-            )
-            raise LogLineIsTooLongError('The max log line size allowed is %r bytes'
-                % MAX_LINE_SIZE_IN_BYTES)
+                # log the origin of the stream with traceback to WHO_CLOG_LARGE_LINE_STREAM category
+                origin_info = {}
+                origin_info['stream'] = stream
+                origin_info['line_size'] = len(line)
+                origin_info['traceback'] = ''.join(traceback.format_stack())
+                log_line = json.dumps(origin_info).encode('UTF-8')
+                self._log_line_no_size_limit(WHO_CLOG_LARGE_LINE_STREAM, log_line)
+                self.report_status(
+                    False,
+                    'The log line size is larger than %r bytes (monitored in \'%s\')'
+                    % (WARNING_LINE_SIZE_IN_BYTES, WHO_CLOG_LARGE_LINE_STREAM)
+                )
+            else:
+                # raise an exception if too large
+                self.report_status(
+                    True,
+                    'The log line is dropped (line size larger than %r bytes)'
+                    % MAX_LINE_SIZE_IN_BYTES
+                )
+                raise LogLineIsTooLongError('The max log line size allowed is %r bytes'
+                    % MAX_LINE_SIZE_IN_BYTES)
+
 
     def close(self):
         self.transport.close()

--- a/clog/metrics_reporter.py
+++ b/clog/metrics_reporter.py
@@ -16,27 +16,73 @@
 
 from contextlib import contextmanager
 
-from yelp_meteorite import create_counter
-from yelp_meteorite import create_timer
+try:
+    from yelp_meteorite import create_counter
+    from yelp_meteorite import create_timer
+except ImportError:
+    # We'll handle the NameErrors and return a FakeMetric within a try/except
+    pass
 
-METRICS_SAMPLE_PREFIX = 'yelp_clog.sample.'
-METRICS_SAMPLE_RATE = 1000  # TODO consider configuring this elsewhere
+
+class FakeMetric(object):
+    """Fake Metric object for use when yelp_meteorite isn't available."""
+    def count(self, *args, **kwargs):
+        pass
+
+    def start(self, *args, **kwargs):
+        pass
+
+    def stop(self, *args, **kwargs):
+        pass
+
+
+METRICS_PREFIX = 'yelp_clog.'
+METRICS_SAMPLE_PREFIX = METRICS_PREFIX + 'sample.'
+METRICS_TOTAL_PREFIX = METRICS_PREFIX + 'total.'
 LOG_LINE_SENT = 'log_line.sent'
 LOG_LINE_LATENCY = 'log_line.latency'
 
 
+def _create_or_fake_counter(*args, **kwargs):
+    """Create a Counter metric if yelp_meteorite is loaded (passing args), otherwise return a fake
+    :return: Counter metric object
+    """
+    try:
+        return create_counter(*args, **kwargs)
+    except NameError:
+        return FakeMetric()
+
+
+def _create_or_fake_timer(*args, **kwargs):
+    """Create a Timer metric if yelp_meteorite is loaded (passing args), otherwise return a fake
+    :return: Timer metric object
+    """
+    try:
+        return create_timer(*args, **kwargs)
+    except NameError:
+        return FakeMetric()
+
+
 class MetricsReporter(object):
-    """Basic metrics reporter that reports on a sampled fraction of requests"""
+    """Basic metrics reporter that reports on a sampled fraction of requests.
+
+    Not thread-safe, thus is called from within the context of ScribeLogger's existing RLock.
+    """
 
     _sample_counter = 0
-    _sample_log_line_sent = create_counter(METRICS_SAMPLE_PREFIX + LOG_LINE_SENT)
-    _sample_log_line_latency = create_timer(METRICS_SAMPLE_PREFIX + LOG_LINE_LATENCY)
+    _sample_log_line_sent = _create_or_fake_counter(METRICS_SAMPLE_PREFIX + LOG_LINE_SENT)
+    _sample_log_line_latency = _create_or_fake_timer(METRICS_SAMPLE_PREFIX + LOG_LINE_LATENCY)
+    _total_log_line_sent = _create_or_fake_counter(METRICS_TOTAL_PREFIX + LOG_LINE_SENT)
+
+    def __init__(self, sample_rate=0):
+        self._sample_rate = sample_rate
 
     @contextmanager
-    def sampled_request(self, sample_rate=METRICS_SAMPLE_RATE):
+    def sampled_request(self):
         """Context manager that records metrics if it's selected as part of the sample, otherwise runs as usual."""
         self._sample_counter += 1
-        if self._sample_counter % sample_rate == 0:
+        if self._sample_rate and self._sample_counter % self._sample_rate == 0:
+            self._total_log_line_sent.count(value=self._sample_counter);
             self._sample_counter = 0
             self._sample_log_line_latency.start()
             yield  # Do the actual work

--- a/clog/metrics_reporter.py
+++ b/clog/metrics_reporter.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from contextlib import contextmanager
+
+from yelp_meteorite import create_counter
+from yelp_meteorite import create_timer
+
+METRICS_SAMPLE_PREFIX = 'yelp_clog.sample.'
+METRICS_SAMPLE_RATE = 1000  # TODO consider configuring this elsewhere
+LOG_LINE_SENT = 'log_line.sent'
+LOG_LINE_LATENCY = 'log_line.latency'
+
+
+class MetricsReporter(object):
+    """Basic metrics reporter that reports on a sampled fraction of requests"""
+
+    _sample_counter = 0
+    _sample_log_line_sent = create_counter(METRICS_SAMPLE_PREFIX + LOG_LINE_SENT)
+    _sample_log_line_latency = create_timer(METRICS_SAMPLE_PREFIX + LOG_LINE_LATENCY)
+
+    @contextmanager
+    def sampled_request(self, sample_rate=METRICS_SAMPLE_RATE):
+        """Context manager that records metrics if it's selected as part of the sample, otherwise runs as usual."""
+        self._sample_counter += 1
+        if self._sample_counter % sample_rate == 0:
+            self._sample_counter = 0
+            self._sample_log_line_latency.start()
+            yield  # Do the actual work
+            self._sample_log_line_latency.stop()
+            self._sample_log_line_sent.count()
+        else:
+            yield  # Do the actual work

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 boto
 PyYAML
 simplejson
-yelp-meteorite

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto
 PyYAML
 simplejson
+yelp-meteorite

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'PyStaticConfiguration >= 0.10.3',
         'simplejson',
         'six>=1.4.0',
+        'yelp-meteorite',
     ],
     extras_require={
         'uwsgi': ['uWSGI'],

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ setup(
         'PyStaticConfiguration >= 0.10.3',
         'simplejson',
         'six>=1.4.0',
-        'yelp-meteorite',
     ],
     extras_require={
         'uwsgi': ['uWSGI'],
+        'internal': ['yelp_meteorite']
     },
     classifiers=[
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     },
     classifiers=[
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/test_metrics_reporter.py
+++ b/tests/test_metrics_reporter.py
@@ -44,7 +44,7 @@ class TestMetricsReporter(object):
         with metrics.sampled_request():
             assert not mock_sample_log_line_sent_count.called
             assert metrics._sample_counter == 0
-        assert mock_sample_log_line_sent_count.called is True
+        assert mock_sample_log_line_sent_count.call_count == 1
 
     @mock.patch('clog.metrics_reporter.MetricsReporter._sample_log_line_sent.count')
     def test_zero_sample_rate(self, mock_sample_log_line_sent_count):
@@ -60,13 +60,13 @@ class TestMetricsReporter(object):
     def test_fake_counter_creation(self, mock_create_counter):
         from clog.metrics_reporter import _create_or_fake_counter
         assert type(_create_or_fake_counter("my_counter")) is FakeMetric
-        assert mock_create_counter.called is True
+        assert mock_create_counter.call_count == 1
 
     @mock.patch('clog.metrics_reporter.create_timer', create=True, side_effect=NameError)
     def test_fake_timer_creation(self, mock_create_timer):
         from clog.metrics_reporter import _create_or_fake_timer
         assert type(_create_or_fake_timer("my_timer")) is FakeMetric
-        assert mock_create_timer.called is True
+        assert mock_create_timer.call_count == 1
 
     def test_fake_metric_functionality(self):
         metrics = MetricsReporter(sample_rate=1)

--- a/tests/test_metrics_reporter.py
+++ b/tests/test_metrics_reporter.py
@@ -16,6 +16,7 @@
 import pytest
 import mock
 
+from clog.metrics_reporter import FakeMetric
 from clog.metrics_reporter import MetricsReporter
 
 
@@ -24,24 +25,58 @@ class TestMetricsReporter(object):
 
     @mock.patch('clog.metrics_reporter.MetricsReporter._sample_log_line_sent.count')
     def test_metrics_reporter_sampling(self, mock_sample_log_line_sent_count):
-        metrics = MetricsReporter()
+        metrics = MetricsReporter(sample_rate=3)
+
         assert metrics._sample_counter == 0
         # First try, not part of sample
-        with metrics.sampled_request(sample_rate=3):
+        with metrics.sampled_request():
             assert not mock_sample_log_line_sent_count.called
             assert metrics._sample_counter == 1
         assert not mock_sample_log_line_sent_count.called
 
         # Second try, not part of sample
-        with metrics.sampled_request(sample_rate=3):
+        with metrics.sampled_request():
             assert not mock_sample_log_line_sent_count.called
             assert metrics._sample_counter == 2
         assert not mock_sample_log_line_sent_count.called
 
         # Third try, part of sample, so called outside the context
-        with metrics.sampled_request(sample_rate=3):
+        with metrics.sampled_request():
             assert not mock_sample_log_line_sent_count.called
             assert metrics._sample_counter == 0
         assert mock_sample_log_line_sent_count.called is True
 
+    @mock.patch('clog.metrics_reporter.MetricsReporter._sample_log_line_sent.count')
+    def test_zero_sample_rate(self, mock_sample_log_line_sent_count):
+        metrics = MetricsReporter(sample_rate=0)
+        assert metrics._sample_counter == 0
+        # Should never sample
+        with metrics.sampled_request():
+            assert not mock_sample_log_line_sent_count.called
+            assert metrics._sample_counter == 1
+        assert not mock_sample_log_line_sent_count.called
+
+    @mock.patch('clog.metrics_reporter.create_counter', create=True, side_effect=NameError)
+    def test_fake_counter_creation(self, mock_create_counter):
+        from clog.metrics_reporter import _create_or_fake_counter
+        assert type(_create_or_fake_counter("my_counter")) is FakeMetric
+        assert mock_create_counter.called is True
+
+    @mock.patch('clog.metrics_reporter.create_timer', create=True, side_effect=NameError)
+    def test_fake_timer_creation(self, mock_create_timer):
+        from clog.metrics_reporter import _create_or_fake_timer
+        assert type(_create_or_fake_timer("my_timer")) is FakeMetric
+        assert mock_create_timer.called is True
+
+    def test_fake_metric_functionality(self):
+        metrics = MetricsReporter(sample_rate=1)
+        # Monkeypatch in the fake counters
+        metrics._sample_log_line_sent = FakeMetric()
+        metrics._sample_log_line_latency = FakeMetric()
+        metrics._total_log_line_sent = FakeMetric()
+
+        assert metrics._sample_counter == 0
+        # First try, not part of sample
+        with metrics.sampled_request():
+            assert metrics._sample_counter == 0
 

--- a/tests/test_metrics_reporter.py
+++ b/tests/test_metrics_reporter.py
@@ -23,7 +23,7 @@ from clog.metrics_reporter import MetricsReporter
 @pytest.mark.acceptance_suite
 class TestMetricsReporter(object):
 
-    @mock.patch('clog.metrics_reporter.MetricsReporter._sample_log_line_sent.count')
+    @mock.patch('clog.metrics_reporter.MetricsReporter._sample_log_line_sent.count', autospec=True)
     def test_metrics_reporter_sampling(self, mock_sample_log_line_sent_count):
         metrics = MetricsReporter(sample_rate=3)
 
@@ -46,7 +46,7 @@ class TestMetricsReporter(object):
             assert metrics._sample_counter == 0
         assert mock_sample_log_line_sent_count.call_count == 1
 
-    @mock.patch('clog.metrics_reporter.MetricsReporter._sample_log_line_sent.count')
+    @mock.patch('clog.metrics_reporter.MetricsReporter._sample_log_line_sent.count', autospec=True)
     def test_zero_sample_rate(self, mock_sample_log_line_sent_count):
         metrics = MetricsReporter(sample_rate=0)
         assert metrics._sample_counter == 0

--- a/tests/test_metrics_reporter.py
+++ b/tests/test_metrics_reporter.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import mock
+
+from clog.metrics_reporter import MetricsReporter
+
+
+@pytest.mark.acceptance_suite
+class TestMetricsReporter(object):
+
+    @mock.patch('clog.metrics_reporter.MetricsReporter._sample_log_line_sent.count')
+    def test_metrics_reporter_sampling(self, mock_sample_log_line_sent_count):
+        metrics = MetricsReporter()
+        assert metrics._sample_counter == 0
+        # First try, not part of sample
+        with metrics.sampled_request(sample_rate=3):
+            assert not mock_sample_log_line_sent_count.called
+            assert metrics._sample_counter == 1
+        assert not mock_sample_log_line_sent_count.called
+
+        # Second try, not part of sample
+        with metrics.sampled_request(sample_rate=3):
+            assert not mock_sample_log_line_sent_count.called
+            assert metrics._sample_counter == 2
+        assert not mock_sample_log_line_sent_count.called
+
+        # Third try, part of sample, so called outside the context
+        with metrics.sampled_request(sample_rate=3):
+            assert not mock_sample_log_line_sent_count.called
+            assert metrics._sample_counter == 0
+        assert mock_sample_log_line_sent_count.called is True
+
+


### PR DESCRIPTION
Should probably figure out what our plan to deploy and configure it (right now just using a static 1/1000 sampling rate), but this should at least have the logging there.