### PR TITLE
Add log_line Zipkin instrumentation support

### DIFF
--- a/clog/config.py
+++ b/clog/config.py
@@ -116,6 +116,10 @@ use_kafka = clog_namespace.get_bool('use_kafka',
     default=False,
     help='If True, will tail from a stream via a service talking to Kafka')
 
+use_zipkin = clog_namespace.get_bool('use_zipkin',
+    default=False,
+    help='Whether to instrument loggers .log_line method with Zipkin.')
+
 metrics_sample_rate = clog_namespace.get_int('metrics_sample_rate',
     default=0,
     help='Number of messages to sample to emit one latency metric.')

--- a/clog/global_state.py
+++ b/clog/global_state.py
@@ -18,7 +18,7 @@ Log lines to scribe using the default global logger.
 
 from clog import config
 from clog.loggers import FileLogger, MonkLogger, ScribeLogger, StdoutLogger
-from clog.zipkin_plugin import use_zipkin, ZipkinLogger
+from clog.zipkin_plugin import use_zipkin, ZipkinTracing
 
 # global logger, used by module-level functions
 loggers = None
@@ -56,7 +56,7 @@ def check_create_default_loggers():
             loggers.append(MonkLogger(config.monk_client_id))
 
         if use_zipkin():
-            loggers = map(ZipkinLogger, loggers)
+            loggers = map(ZipkinTracing, loggers)
 
         if not loggers and not config.is_logging_configured:
             raise LoggingNotConfiguredError

--- a/clog/global_state.py
+++ b/clog/global_state.py
@@ -18,6 +18,7 @@ Log lines to scribe using the default global logger.
 
 from clog import config
 from clog.loggers import FileLogger, MonkLogger, ScribeLogger, StdoutLogger
+from clog.zipkin_plugin import use_zipkin, ZipkinLogger
 
 # global logger, used by module-level functions
 loggers = None
@@ -53,6 +54,9 @@ def check_create_default_loggers():
 
         if not config.monk_disable:
             loggers.append(MonkLogger(config.monk_client_id))
+
+        if use_zipkin():
+            loggers = map(ZipkinLogger, loggers)
 
         if not loggers and not config.is_logging_configured:
             raise LoggingNotConfiguredError

--- a/clog/handlers.py
+++ b/clog/handlers.py
@@ -23,6 +23,7 @@ import logging
 from clog.loggers import MonkLogger
 from clog.loggers import ScribeLogger
 from clog.utils import scribify
+from clog.zipkin_plugin import use_zipkin, ZipkinTracing
 from clog import global_state
 
 
@@ -45,6 +46,8 @@ class CLogHandler(logging.Handler):
         'If no logger is specified, the global one is used'
         logging.Handler.__init__(self)
         self.stream = stream
+        if logger is not None and use_zipkin():
+            logger = ZipkinTracing(logger)
         self.logger = logger or global_state
 
     def emit(self, record):
@@ -78,6 +81,8 @@ class ScribeHandler(logging.Handler):
         logging.Handler.__init__(self)
         self.stream = stream
         self.logger = ScribeLogger(host, port, retry_interval)
+        if use_zipkin():
+            self.logger = ZipkinTracing(self.logger)
 
     def emit(self, record):
         try:

--- a/clog/zipkin_plugin.py
+++ b/clog/zipkin_plugin.py
@@ -15,14 +15,14 @@ def use_zipkin():
     return zipkin_plugin_enabled and config.use_zipkin
 
 
-class ZipkinLogger(object):
+class ZipkinTracing(object):
     """Wrapper class to instrument log_line calls with Zipkin.
 
     This class is meant to be used if use_zipkin() returns True.
     e.g:
         logger = MyLogger()
         if use_zipkin():
-            logger = ZipkinLogger(logger)
+            logger = ZipkinTracing(logger)
 
     Each call to log_line will add a Zipkin Span and call the underlying
     log_line, all other method call will only call the corresponding method

--- a/clog/zipkin_plugin.py
+++ b/clog/zipkin_plugin.py
@@ -1,0 +1,51 @@
+from __future__ import print_function
+from __future__ import with_statement
+
+from clog import config
+
+zipkin_plugin_enabled = False
+try:
+    from py_zipkin.zipkin import zipkin_span
+    zipkin_plugin_enabled = True
+except ImportError:
+    pass
+
+
+def use_zipkin():
+    return zipkin_plugin_enabled and config.use_zipkin
+
+
+class ZipkinLogger(object):
+    """Wrapper class to instrument log_line calls with Zipkin.
+
+    This class is meant to be used if use_zipkin() returns True.
+    e.g:
+        logger = MyLogger()
+        if use_zipkin():
+            logger = ZipkinLogger(logger)
+
+    Each call to log_line will add a Zipkin Span and call the underlying
+    log_line, all other method call will only call the corresponding method
+    of the underlying logger object.
+
+    :param logger: a logger instance, must have a log_line(stream, line) method
+    """
+
+    def __init__(self, logger):
+        assert use_zipkin()
+
+        self.logger = logger
+        self.logger_name = self.logger.__class__.__name__
+
+    def log_line(self, stream, line):
+        with zipkin_span(
+            service_name='yelp_clog',
+            span_name='{name}.log_line {stream}'.format(
+                name=self.logger_name,
+                stream=stream,
+            ),
+        ):
+            return self.logger.log_line(stream, line)
+
+    def __getattr__(self, item):
+        return getattr(self.logger, item)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'six>=1.4.0',
     ],
     extras_require={
+        'zipkin': ['py_zipkin'],
         'uwsgi': ['uWSGI'],
         'internal': ['yelp_meteorite', 'monk==0.1.20']
     },

--- a/testing/sandbox.py
+++ b/testing/sandbox.py
@@ -41,7 +41,7 @@ def find_open_port():
     s = socket.socket()
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.bind(('0.0.0.0', 0))
-    s.listen(0)
+    s.listen(1)
 
     sockname = s.getsockname()
 

--- a/tests/test_zipkin_plugin.py
+++ b/tests/test_zipkin_plugin.py
@@ -1,0 +1,62 @@
+import mock
+import pytest
+
+from clog.loggers import MockLogger
+
+
+def mock_zipkin_span():
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def zipkin_plugin():
+    import clog.zipkin_plugin
+
+    if not clog.zipkin_plugin.zipkin_plugin_enabled:
+        clog.zipkin_plugin.zipkin_span = mock_zipkin_span
+    yield clog.zipkin_plugin
+
+
+@pytest.fixture
+def use_zipkin(zipkin_plugin):
+    zipkin_plugin.zipkin_plugin_enabled = True
+    zipkin_plugin.config.use_zipkin = True
+    yield
+
+
+@pytest.fixture
+def no_use_zipkin(zipkin_plugin):
+    zipkin_plugin.zipkin_plugin_enabled = False
+    yield
+
+
+class TestZipkinPlugin(object):
+
+    def test_use_zipkin(self, zipkin_plugin, use_zipkin):
+        assert zipkin_plugin.use_zipkin()
+
+    def test_no_use_zipkin(self, zipkin_plugin, no_use_zipkin):
+        assert not zipkin_plugin.use_zipkin()
+
+    def test_logger_no_use_zipkin(self, zipkin_plugin, no_use_zipkin):
+        with pytest.raises(AssertionError):
+            zipkin_plugin.ZipkinLogger(MockLogger())
+
+    def test_log_line(self, zipkin_plugin, use_zipkin):
+        with mock.patch.object(zipkin_plugin, 'zipkin_span') as zipkin_span:
+            logger = zipkin_plugin.ZipkinLogger(MockLogger())
+            logger.log_line('stream', 'line')
+
+        assert logger.logger.lines == {'stream': ['line']}
+        assert zipkin_span.call_count == 1
+        zipkin_span.assert_called_with(
+            service_name='yelp_clog',
+            span_name='MockLogger.log_line stream',
+        )
+
+    def test_other(self, zipkin_plugin, use_zipkin):
+        with mock.patch.object(zipkin_plugin, 'zipkin_span') as zipkin_span:
+            logger = zipkin_plugin.ZipkinLogger(MockLogger())
+            logger.close()
+
+        assert zipkin_span.call_count == 0

--- a/tests/test_zipkin_plugin.py
+++ b/tests/test_zipkin_plugin.py
@@ -40,11 +40,11 @@ class TestZipkinPlugin(object):
 
     def test_logger_no_use_zipkin(self, zipkin_plugin, no_use_zipkin):
         with pytest.raises(AssertionError):
-            zipkin_plugin.ZipkinLogger(MockLogger())
+            zipkin_plugin.ZipkinTracing(MockLogger())
 
     def test_log_line(self, zipkin_plugin, use_zipkin):
         with mock.patch.object(zipkin_plugin, 'zipkin_span') as zipkin_span:
-            logger = zipkin_plugin.ZipkinLogger(MockLogger())
+            logger = zipkin_plugin.ZipkinTracing(MockLogger())
             logger.log_line('stream', 'line')
 
         assert logger.logger.lines == {'stream': ['line']}
@@ -56,7 +56,7 @@ class TestZipkinPlugin(object):
 
     def test_other(self, zipkin_plugin, use_zipkin):
         with mock.patch.object(zipkin_plugin, 'zipkin_span') as zipkin_span:
-            logger = zipkin_plugin.ZipkinLogger(MockLogger())
+            logger = zipkin_plugin.ZipkinTracing(MockLogger())
             logger.close()
 
         assert zipkin_span.call_count == 0


### PR DESCRIPTION
If py_zipkin is installed and use_zipkin setting is set to True, calls to .log_line
of any logger will be instrumented with Zipkin.

service_name=yelp_clog span_name={LoggerClass}.log_line {stream}

