### PR TITLE
Clog monk improvements

### DIFF
--- a/clog/config.py
+++ b/clog/config.py
@@ -93,7 +93,9 @@ default_backend = clog_namespace.get_string('default_backend',
 stream_backend = clog_namespace.get_list('stream_backend',
     default=[],
     help="The map of stream names to backend ('scribe', 'monk' or 'dual'). "
-    "If not specified, the default one will be used."
+    "If not specified, the default one will be used. The mapping must be "
+    "represente as a list using the format\n"
+    "    - stream_name: backend_name"
 )
 
 monk_client_id = clog_namespace.get_string('monk_client_id',
@@ -111,7 +113,7 @@ monk_timeout_ms = clog_namespace.get_int('monk_timeout_ms',
           "will try again."))
 
 monk_timeout_backoff_ms = clog_namespace.get_int('monk_timeout_backoff_ms',
-    default=5000,
+    default=2000,
     help=("After a timeout occurs, clog won't write to Monk for as many "
           "milliseconds as defined here"))
 

--- a/clog/config.py
+++ b/clog/config.py
@@ -94,6 +94,17 @@ monk_stream_prefix = clog_namespace.get_string('monk_stream_prefix',
     default="",
     help="clog-specific prefix to be added to every stream name")
 
+monk_timeout_ms = clog_namespace.get_int('monk_timeout_ms',
+    default=100,
+    help=("Timeout while writing to Monk. After a timeout occurs, "
+          "clog won't write to Monk for `monk_timeout_backoff_ms`, then it "
+          "will try again"))
+
+monk_timeout_backoff_ms = clog_namespace.get_int('monk_timeout_backoff_ms',
+    default=5000,
+    help=("After a timeout occurs, clog won't write to Monk for as many "
+          "milliseconds as defined here"))
+
 scribe_host = clog_namespace.get_string('scribe_host',
     help="Hostname of the scribe server.")
 

--- a/clog/config.py
+++ b/clog/config.py
@@ -86,6 +86,16 @@ monk_disable = clog_namespace.get_bool('monk_disable',
     default=True,
     help="Disable writing logs to monk.")
 
+default_backend = clog_namespace.get_string('default_backend',
+    default="scribe",
+    help="The default backend to use (can be 'scribe', 'monk' or 'dual')")
+
+stream_backend = clog_namespace.get_list('stream_backend',
+    default=[],
+    help="The map of stream names to backend ('scribe', 'monk' or 'dual'). "
+    "If not specified, the default one will be used."
+)
+
 monk_client_id = clog_namespace.get_string('monk_client_id',
     default="clog",
     help="Identification for user writing to monk")
@@ -98,7 +108,7 @@ monk_timeout_ms = clog_namespace.get_int('monk_timeout_ms',
     default=100,
     help=("Timeout while writing to Monk. After a timeout occurs, "
           "clog won't write to Monk for `monk_timeout_backoff_ms`, then it "
-          "will try again"))
+          "will try again."))
 
 monk_timeout_backoff_ms = clog_namespace.get_int('monk_timeout_backoff_ms',
     default=5000,

--- a/clog/config.py
+++ b/clog/config.py
@@ -90,6 +90,10 @@ monk_client_id = clog_namespace.get_string('monk_client_id',
     default="clog",
     help="Identification for user writing to monk")
 
+monk_stream_prefix = clog_namespace.get_string('monk_stream_prefix',
+    default="",
+    help="clog-specific prefix to be added to every stream name")
+
 scribe_host = clog_namespace.get_string('scribe_host',
     help="Hostname of the scribe server.")
 

--- a/clog/config.py
+++ b/clog/config.py
@@ -104,7 +104,7 @@ monk_client_id = clog_namespace.get_string('monk_client_id',
 
 monk_stream_prefix = clog_namespace.get_string('monk_stream_prefix',
     default="",
-    help="clog-specific prefix to be added to every stream name")
+    help="This prefix will be added to all the streams being produced to Monk.")
 
 monk_timeout_ms = clog_namespace.get_int('monk_timeout_ms',
     default=100,

--- a/clog/global_state.py
+++ b/clog/global_state.py
@@ -52,7 +52,6 @@ def check_create_default_loggers():
         if config.clog_enable_stdout_logging:
             loggers.append(StdoutLogger())
 
-        print config.monk_disable
         if not config.monk_disable:
             loggers.append(MonkLogger(config.monk_client_id))
 

--- a/clog/global_state.py
+++ b/clog/global_state.py
@@ -26,6 +26,18 @@ loggers = None
 class LoggingNotConfiguredError(Exception):
     pass
 
+
+def create_stream_backend_map():
+    """PyStaticConfig doesn't allow us to have a map in the configuration,
+    so we represent a map as a list, and we use this function to generate
+    an actual python dictionary from it."""
+    stream_backend_map = {}
+    for mapping in config.stream_backend:
+        key, value = mapping.items()[0]
+        stream_backend_map[key] = value
+    return stream_backend_map
+
+
 def check_create_default_loggers():
     """Set up global loggers, if necessary."""
     global loggers
@@ -58,12 +70,9 @@ def check_create_default_loggers():
         if config.clog_enable_stdout_logging:
             loggers.append(StdoutLogger())
 
-        print(">>>  " + str(config.default_backend))
-        print(">>>  " + str(config.monk_disable))
         if not config.monk_disable:
             loggers.append(MonkLogger(config.monk_client_id))
         else:
-            print(">>>  " + str(config.default_backend))
             if (config.default_backend in ('monk', 'dual') or \
                 any(b in ('monk', 'dual') for b in config.stream_backend_map.values())):
                 raise Exception("Monk is used as a backend but it's not enabled")
@@ -73,14 +82,6 @@ def check_create_default_loggers():
 
         if not loggers and not config.is_logging_configured:
             raise LoggingNotConfiguredError
-
-
-def create_stream_backend_map():
-    stream_backend_map = {}
-    for mapping in config.stream_backend:
-        key, value = mapping.items()[0]
-        stream_backend_map[key] = value
-    return stream_backend_map
 
 
 def reset_default_loggers():

--- a/clog/global_state.py
+++ b/clog/global_state.py
@@ -52,6 +52,7 @@ def check_create_default_loggers():
         if config.clog_enable_stdout_logging:
             loggers.append(StdoutLogger())
 
+        print config.monk_disable
         if not config.monk_disable:
             loggers.append(MonkLogger(config.monk_client_id))
 

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -38,7 +38,7 @@ import pkg_resources
 import thriftpy
 try:
     from monk.producers import MonkProducer
-except ImportError as e:
+except ImportError:
     pass
 
 from clog import config

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -269,8 +269,7 @@ class MonkLogger(object):
             client_id,
             host,
             port,
-            # timeout_ms=config.monk_timeout_ms,  TODO REVERT
-            timeout=config.monk_timeout_ms,
+            timeout_ms=config.monk_timeout_ms,
             collect_metrics=False
         )
 

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -26,6 +26,7 @@ import os
 import os.path
 import sys
 import syslog
+import socket
 import threading
 import time
 import traceback
@@ -250,19 +251,38 @@ class ScribeLogger(object):
 class MonkLogger(object):
     """Wrapper around MonkProducer"""
 
-    def __init__(self, client_id, host=None, port=None):
-        self.producer = MonkProducer(client_id, host, port, collect_metrics=False)
+    def __init__(self, client_id, host=None, port=None, timeout_backoff_ms=5000):
+        self.stream_prefix = config.monk_stream_prefix
         self.report_status = get_default_reporter()
         self.metrics = MetricsReporter(
             sample_rate=config.metrics_sample_rate,
             backend="monk"
         )
+        self.timeout_backoff_s = timeout_backoff_ms / 1000
+        self.last_timeout = time.time() - self.timeout_backoff_s
+        self.producer = MonkProducer(
+            client_id,
+            host,
+            port,
+            timeout_ms=100,
+            collect_metrics=False
+        )
 
     def log_line(self, stream, line):
+        if time.time() < self.last_timeout + self.timeout_backoff_s:
+            self.metrics.monk_exception()
+            return
         with self.metrics.sampled_request():
             try:
-                clog_stream = '_clog.{0}'.format(stream)
-                self.producer.send_messages(clog_stream, [line], None)
+                self.producer.send_messages(
+                    self.stream_prefix + stream,
+                    [line],
+                    None
+                )
+            except socket.timeout as e:
+                self.report_status(True, 'Monk took too long to respond')
+                self.last_timeout = time.time()
+                self.metrics.monk_exception()
             except Exception as e:
                 self.report_status(
                     True,

--- a/clog/metrics_reporter.py
+++ b/clog/metrics_reporter.py
@@ -104,8 +104,8 @@ class MetricsReporter(object):
         if sample_request:
             start_time = time.time()
             yield  # Do the actual work
+            duration = _convert_to_microseconds(time.time() - start_time)
             with self._lock:
-                duration = _convert_to_microseconds(time.time() - start_time)
                 self._total_log_line_sent.count(value=self._sample_counter);
                 self._sample_log_line_sent.count()
                 self._sample_log_line_latency.record(value=duration)

--- a/clog/metrics_reporter.py
+++ b/clog/metrics_reporter.py
@@ -114,4 +114,5 @@ class MetricsReporter(object):
             yield  # Do the actual work
 
     def monk_exception(self):
-        self._monk_exception_counter.count(1)
+        with self._lock:
+            self._monk_exception_counter.count(1)

--- a/clog/metrics_reporter.py
+++ b/clog/metrics_reporter.py
@@ -16,6 +16,7 @@
 
 from contextlib import contextmanager
 
+import threading
 import time
 
 try:
@@ -40,6 +41,7 @@ METRICS_SAMPLE_PREFIX = METRICS_PREFIX + 'sample.'
 METRICS_TOTAL_PREFIX = METRICS_PREFIX + 'total.'
 LOG_LINE_SENT = 'log_line.sent'
 LOG_LINE_LATENCY = 'log_line.latency_microseconds'
+LOG_LINE_MONK_EXCEPTION = 'log_line.monk_exception'
 
 
 def _create_or_fake_counter(*args, **kwargs):
@@ -68,29 +70,48 @@ def _convert_to_microseconds(seconds):
 
 class MetricsReporter(object):
     """Basic metrics reporter that reports on a sampled fraction of requests.
-
-    Not thread-safe, thus is called from within the context of ScribeLogger's existing RLock.
     """
 
-    _sample_counter = 0
-    _sample_log_line_sent = _create_or_fake_counter(METRICS_SAMPLE_PREFIX + LOG_LINE_SENT)
-    _sample_log_line_latency = _create_or_fake_timer(METRICS_SAMPLE_PREFIX + LOG_LINE_LATENCY)
-    _total_log_line_sent = _create_or_fake_counter(METRICS_TOTAL_PREFIX + LOG_LINE_SENT)
-
-    def __init__(self, sample_rate=0):
+    def __init__(self, backend, sample_rate=0):
+        default_dimensions = { 'backend': backend }
+        self._sample_counter = 0
+        self._sample_log_line_sent = _create_or_fake_counter(
+            METRICS_SAMPLE_PREFIX + LOG_LINE_SENT,
+            default_dimensions
+        )
+        self._sample_log_line_latency = _create_or_fake_timer(
+            METRICS_SAMPLE_PREFIX + LOG_LINE_LATENCY,
+            default_dimensions
+        )
+        self._total_log_line_sent = _create_or_fake_counter(
+            METRICS_TOTAL_PREFIX + LOG_LINE_SENT,
+            default_dimensions
+        )
+        self._monk_exception_counter = _create_or_fake_counter(
+            METRICS_TOTAL_PREFIX + LOG_LINE_MONK_EXCEPTION,
+            default_dimensions
+        )
         self._sample_rate = sample_rate
+        self._lock = threading.RLock()
 
     @contextmanager
     def sampled_request(self):
         """Context manager that records metrics if it's selected as part of the sample, otherwise runs as usual."""
-        self._sample_counter += 1
-        if self._sample_rate and self._sample_counter % self._sample_rate == 0:
-            self._total_log_line_sent.count(value=self._sample_counter);
-            self._sample_counter = 0
+        sample_request = False
+        with self._lock:
+            self._sample_counter += 1
+            sample_request = self._sample_rate and self._sample_counter % self._sample_rate == 0
+        if sample_request:
             start_time = time.time()
             yield  # Do the actual work
-            self._sample_log_line_sent.count()
-            duration = _convert_to_microseconds(time.time() - start_time)
-            self._sample_log_line_latency.record(value=duration)
+            with self._lock:
+                duration = _convert_to_microseconds(time.time() - start_time)
+                self._total_log_line_sent.count(value=self._sample_counter);
+                self._sample_log_line_sent.count()
+                self._sample_log_line_latency.record(value=duration)
+                self._sample_counter = 0
         else:
             yield  # Do the actual work
+
+    def monk_exception(self):
+        self._monk_exception_counter.count(1)

--- a/clog/metrics_reporter.py
+++ b/clog/metrics_reporter.py
@@ -42,6 +42,7 @@ METRICS_TOTAL_PREFIX = METRICS_PREFIX + 'total.'
 LOG_LINE_SENT = 'log_line.sent'
 LOG_LINE_LATENCY = 'log_line.latency_microseconds'
 LOG_LINE_MONK_EXCEPTION = 'log_line.monk_exception'
+LOG_LINE_MONK_TIMEOUT = 'log_line.monk_timeout'
 
 
 def _create_or_fake_counter(*args, **kwargs):
@@ -91,6 +92,10 @@ class MetricsReporter(object):
             METRICS_TOTAL_PREFIX + LOG_LINE_MONK_EXCEPTION,
             default_dimensions
         )
+        self._monk_timeout_counter = _create_or_fake_counter(
+            METRICS_TOTAL_PREFIX + LOG_LINE_MONK_TIMEOUT,
+            default_dimensions
+        )
         self._sample_rate = sample_rate
         self._lock = threading.RLock()
 
@@ -114,5 +119,11 @@ class MetricsReporter(object):
             yield  # Do the actual work
 
     def monk_exception(self):
+        """Increases the monk exception counter by 1"""
         with self._lock:
             self._monk_exception_counter.count(1)
+
+    def monk_timeout(self):
+        """Increases the monk timeout counter by 1"""
+        with self._lock:
+            self._monk_timeout_counter.count(1)

--- a/clog/metrics_reporter.py
+++ b/clog/metrics_reporter.py
@@ -76,10 +76,6 @@ class MetricsReporter(object):
     def __init__(self, backend, sample_rate=0):
         default_dimensions = { 'backend': backend }
         self._sample_counter = 0
-        self._sample_log_line_sent = _create_or_fake_counter(
-            METRICS_SAMPLE_PREFIX + LOG_LINE_SENT,
-            default_dimensions
-        )
         self._sample_log_line_latency = _create_or_fake_timer(
             METRICS_SAMPLE_PREFIX + LOG_LINE_LATENCY,
             default_dimensions
@@ -112,7 +108,6 @@ class MetricsReporter(object):
             duration = _convert_to_microseconds(time.time() - start_time)
             with self._lock:
                 self._total_log_line_sent.count(value=self._sample_counter);
-                self._sample_log_line_sent.count()
                 self._sample_log_line_latency.record(value=duration)
                 self._sample_counter = 0
         else:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ dumb-init
 mock
 pyflakes
 pytest
+monk

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     extras_require={
         'zipkin': ['py_zipkin'],
         'uwsgi': ['uWSGI'],
-        'internal': ['yelp_meteorite', 'monk==0.1.20']
+        'internal': ['yelp_meteorite', 'monk==0.2.0']
     },
     classifiers=[
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     extras_require={
         'zipkin': ['py_zipkin'],
         'uwsgi': ['uWSGI'],
-        'internal': ['yelp_meteorite', 'monk==0.2.0']
+        'internal': ['yelp_meteorite==1.3.0', 'monk==0.2.1']
     },
     classifiers=[
         'Programming Language :: Python :: 2',

--- a/tests/test_metrics_reporter.py
+++ b/tests/test_metrics_reporter.py
@@ -23,38 +23,39 @@ from clog.metrics_reporter import MetricsReporter
 @pytest.mark.acceptance_suite
 class TestMetricsReporter(object):
 
-    @mock.patch('clog.metrics_reporter.MetricsReporter._sample_log_line_sent.count', autospec=True)
-    def test_metrics_reporter_sampling(self, mock_sample_log_line_sent_count):
-        metrics = MetricsReporter(sample_rate=3)
+    def test_metrics_reporter_sampling(self):
+        metrics = MetricsReporter(backend="test", sample_rate=3)
+        metrics._sample_log_line_sent = mock.Mock(FakeMetric())
 
         assert metrics._sample_counter == 0
         # First try, not part of sample
         with metrics.sampled_request():
-            assert not mock_sample_log_line_sent_count.called
+            assert not metrics._sample_log_line_sent.count.called
             assert metrics._sample_counter == 1
-        assert not mock_sample_log_line_sent_count.called
+        assert not metrics._sample_log_line_sent.count.called
 
         # Second try, not part of sample
         with metrics.sampled_request():
-            assert not mock_sample_log_line_sent_count.called
+            assert not metrics._sample_log_line_sent.count.called
             assert metrics._sample_counter == 2
-        assert not mock_sample_log_line_sent_count.called
+        assert not metrics._sample_log_line_sent.count.called
 
         # Third try, part of sample, so called outside the context
         with metrics.sampled_request():
-            assert not mock_sample_log_line_sent_count.called
-            assert metrics._sample_counter == 0
-        assert mock_sample_log_line_sent_count.call_count == 1
+            assert not metrics._sample_log_line_sent.count.called
+            assert metrics._sample_counter == 3
+        assert metrics._sample_log_line_sent.count.call_count == 1
+        assert metrics._sample_counter == 0
 
-    @mock.patch('clog.metrics_reporter.MetricsReporter._sample_log_line_sent.count', autospec=True)
-    def test_zero_sample_rate(self, mock_sample_log_line_sent_count):
-        metrics = MetricsReporter(sample_rate=0)
+    def test_zero_sample_rate(self):
+        metrics = MetricsReporter(backend="test", sample_rate=0)
+        metrics._sample_log_line_sent = mock.Mock(FakeMetric())
         assert metrics._sample_counter == 0
         # Should never sample
         with metrics.sampled_request():
-            assert not mock_sample_log_line_sent_count.called
+            assert not metrics._sample_log_line_sent.count.called
             assert metrics._sample_counter == 1
-        assert not mock_sample_log_line_sent_count.called
+        assert not metrics._sample_log_line_sent.count.called
 
     @mock.patch('clog.metrics_reporter.create_counter', create=True, side_effect=NameError)
     def test_fake_counter_creation(self, mock_create_counter):
@@ -69,7 +70,7 @@ class TestMetricsReporter(object):
         assert mock_create_timer.call_count == 1
 
     def test_fake_metric_functionality(self):
-        metrics = MetricsReporter(sample_rate=1)
+        metrics = MetricsReporter(backend="test", sample_rate=1)
         # Monkeypatch in the fake counters
         metrics._sample_log_line_sent = FakeMetric()
         metrics._sample_log_line_latency = FakeMetric()
@@ -78,13 +79,14 @@ class TestMetricsReporter(object):
         assert metrics._sample_counter == 0
         # First try, not part of sample
         with metrics.sampled_request():
-            assert metrics._sample_counter == 0
+            assert metrics._sample_counter == 1
+        assert metrics._sample_counter == 0
 
-    @mock.patch('clog.metrics_reporter.MetricsReporter._sample_log_line_latency.record', autospec=True)
-    def test_latency_microseconds(self, mock_latency_record):
-        metrics = MetricsReporter(sample_rate=1)
+    def test_latency_microseconds(self):
+        metrics = MetricsReporter(backend="test", sample_rate=1)
+        metrics._sample_log_line_latency = mock.Mock(FakeMetric())
         with metrics.sampled_request():
             pass
-        assert mock_latency_record.call_count == 1
+        assert metrics._sample_log_line_latency.record.call_count == 1
         # time.time() has a resolution of down to half a microsecond, so seeing under that means we're tracking s or ms.
-        assert mock_latency_record.call_args[1]['value'] > 0.1
+        assert metrics._sample_log_line_latency.record.call_args[1]['value'] > 0.1

--- a/tests/test_metrics_reporter.py
+++ b/tests/test_metrics_reporter.py
@@ -25,37 +25,27 @@ class TestMetricsReporter(object):
 
     def test_metrics_reporter_sampling(self):
         metrics = MetricsReporter(backend="test", sample_rate=3)
-        metrics._sample_log_line_sent = mock.Mock(FakeMetric())
 
         assert metrics._sample_counter == 0
         # First try, not part of sample
         with metrics.sampled_request():
-            assert not metrics._sample_log_line_sent.count.called
             assert metrics._sample_counter == 1
-        assert not metrics._sample_log_line_sent.count.called
 
         # Second try, not part of sample
         with metrics.sampled_request():
-            assert not metrics._sample_log_line_sent.count.called
             assert metrics._sample_counter == 2
-        assert not metrics._sample_log_line_sent.count.called
 
         # Third try, part of sample, so called outside the context
         with metrics.sampled_request():
-            assert not metrics._sample_log_line_sent.count.called
             assert metrics._sample_counter == 3
-        assert metrics._sample_log_line_sent.count.call_count == 1
         assert metrics._sample_counter == 0
 
     def test_zero_sample_rate(self):
         metrics = MetricsReporter(backend="test", sample_rate=0)
-        metrics._sample_log_line_sent = mock.Mock(FakeMetric())
         assert metrics._sample_counter == 0
         # Should never sample
         with metrics.sampled_request():
-            assert not metrics._sample_log_line_sent.count.called
             assert metrics._sample_counter == 1
-        assert not metrics._sample_log_line_sent.count.called
 
     @mock.patch('clog.metrics_reporter.create_counter', create=True, side_effect=NameError)
     def test_fake_counter_creation(self, mock_create_counter):
@@ -72,7 +62,6 @@ class TestMetricsReporter(object):
     def test_fake_metric_functionality(self):
         metrics = MetricsReporter(backend="test", sample_rate=1)
         # Monkeypatch in the fake counters
-        metrics._sample_log_line_sent = FakeMetric()
         metrics._sample_log_line_latency = FakeMetric()
         metrics._total_log_line_sent = FakeMetric()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 # NOTE: pypy is known to work, but we don't have it installed...  yet.
 envlist = py27,py34,py35,py36
-indexserver =
-    default = https://pypi.yelpcorp.com/simple/
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 # NOTE: pypy is known to work, but we don't have it installed...  yet.
 envlist = py27,py34,py35,py36
+indexserver =
+    default = https://pypi.yelpcorp.com/simple/
 
 [testenv]
 deps =


### PR DESCRIPTION
- Emit metrics and log to syslog when messages are discarded because Monk is unavailable
- Handle timeouts: if monk is slow, timeout after 100ms and drop messages for the next 5 seconds, then retry (configurable).
- Monk prefix configurable
- Add optional stream -> backend (monk/scribe/dual) map