### PR TITLE
MONK-292: don't throw exception if Monk clib is not installed

### DIFF
--- a/clog/global_state.py
+++ b/clog/global_state.py
@@ -71,6 +71,8 @@ def check_create_default_loggers():
             loggers.append(StdoutLogger())
 
         if not config.monk_disable:
+            # TODO: this check should be removed once most libraries have
+            # been moved to use the "internal" extra-requires.
             if monk_dependency_installed:
                 logger = MonkLogger(
                     config.monk_client_id,

--- a/clog/global_state.py
+++ b/clog/global_state.py
@@ -17,7 +17,8 @@ Log lines to scribe using the default global logger.
 """
 
 from clog import config
-from clog.loggers import FileLogger, MonkLogger, ScribeLogger, StdoutLogger
+from clog.loggers import FileLogger, get_default_reporter,\
+    monk_dependency_installed, MonkLogger, ScribeLogger, StdoutLogger
 from clog.zipkin_plugin import use_zipkin, ZipkinTracing
 
 # global logger, used by module-level functions
@@ -70,11 +71,16 @@ def check_create_default_loggers():
             loggers.append(StdoutLogger())
 
         if not config.monk_disable:
-            logger = MonkLogger(
-                config.monk_client_id,
-                stream_backend_map=stream_backend_map
-            )
-            loggers.append(logger)
+            if monk_dependency_installed:
+                logger = MonkLogger(
+                    config.monk_client_id,
+                    stream_backend_map=stream_backend_map
+                )
+                loggers.append(logger)
+            else:
+                reporter = get_default_reporter()
+                reporter(True, "Monk dependency not available. Monk logging will be disabled.")
+
 
         if use_zipkin():
             loggers = list(map(ZipkinTracing, loggers))

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -36,9 +36,13 @@ import six
 import pkg_resources
 
 import thriftpy
+
+# Will be set to True if the Monk dependency is installed, False otherwise
+monk_dependency_installed = True
 try:
     from monk.producers import MonkProducer
 except ImportError:
+    monk_dependency_installed = False
     pass
 
 from clog import config

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -37,7 +37,6 @@ import pkg_resources
 
 import thriftpy
 
-# Will be set to True if the Monk dependency is installed, False otherwise
 monk_dependency_installed = True
 try:
     from monk.producers import MonkProducer


### PR DESCRIPTION
If 'monk_disable' is false but Monk is not available as a dependency,
don't throw an exception. This will make transitioning to Monk easier,
since we can set 'monk_disable' to false without having to upgrade all
the existing libraries.