### PR TITLE
Do not necessarily raise an exception when yelp_clog.json is not found

### DIFF
--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -169,8 +169,11 @@ class TestFindTailHost(object):
         assert tail_host == self.TEST_TAIL_HOST
 
     def test_with_file_missing(self, mock_get_settings_failed):
-        with pytest.raises(Exception):
-            readers.find_tail_host(host=self.TEST_HOST)
+        with pytest.raises(IOError):
+            readers.find_tail_host(
+                host=self.TEST_HOST,
+                raise_on_error=True,
+            )
 
     def test_with_host_key_missing(self, mock_get_settings):
         OTHER_TEST_HOST = 'fake-host-2'


### PR DESCRIPTION
This is a more backwards-compatible approach when using
`clog.readers.find_tail_host`. If an old code using yelp-clog
did not have a /etc/yelp_clog.json file, the behaviour will be
the same as it used to (silently fail).

Any caught Exception can be raised using a flag so future
implementations can choose to handle the Exception or not.

I believe the motivation behind raising any `IOError` was due
to some packages/services silently failing when instantiating
a `StreamTailer` and /etc/yelp_clog.json was not present, hence
the `raise_on_error=True` by default when called from
`StreamTailer`.

Also add some documentation for `find_tail_host`, not sure about its
accuracy, though.