### PR TITLE
Do not raise exception when host mapping file is missing

### DIFF
--- a/clog/readers.py
+++ b/clog/readers.py
@@ -295,7 +295,7 @@ class StreamTailer(object):
             # find_tail_host(host) will return host.
             # `host` is usually a Scribe host not a tailer host
             if self.host == host:
-                self.log.warn('Tailing host same as Scribe host. Is {} correct?'.format(SETTINGS_FILE))
+                self.log.warn('No configuration provided. Default tail hostname will be used')
         else:
             self.host = host
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -169,8 +169,10 @@ class TestFindTailHost(object):
         assert tail_host == self.TEST_TAIL_HOST
 
     def test_with_file_missing(self, mock_get_settings_failed):
-        with pytest.raises(Exception):
-            readers.find_tail_host(host=self.TEST_HOST)
+        OTHER_TEST_HOST = 'fake-host-2'
+        tail_host = readers.find_tail_host(host=OTHER_TEST_HOST)
+
+        assert tail_host == OTHER_TEST_HOST
 
     def test_with_host_key_missing(self, mock_get_settings):
         OTHER_TEST_HOST = 'fake-host-2'


### PR DESCRIPTION
This pretty much reverts #46 as this caused severe issues
when upgrading some dependencies.

This is a more backwards-compatible approach when using
`clog.readers.find_tail_host`. If an old code using yelp-clog
did not have a /etc/yelp_clog.json file, the behaviour will be
the same as it used to (silently fail).

I believe the motivation behind raising any `IOError` was due
to some packages/services silently failing when instantiating
a `StreamTailer` and /etc/yelp_clog.json was not present, hence
the logging in the constructor.

Also add some documentation for `find_tail_host`, not sure about its
accuracy, though.