### PR TITLE
Support multiple configuration files

### DIFF
--- a/clog/readers.py
+++ b/clog/readers.py
@@ -43,9 +43,7 @@ _chunkfile_pat = re.compile(r'^(?P<stream>[a-z][-a-z0-9_]+)-(?P<year>\d{4})-(?P<
 
 COMPRESSED_HEADER_FMT = "<Q"
 
-# Configuration files. Clog will check them in order,
-# and use the first existing one.
-SETTINGS_FILES = ['/nail/srv/configs/yelp_clog.json', '/etc/yelp_clog.json']
+SETTINGS_FILE = '/etc/yelp_clog.json'
 
 
 class NoLogDataError(Exception):
@@ -178,19 +176,10 @@ class StreamTailerSetupError(Exception):
     def __repr__(self):
         return "<StreamTailerSetupError host=%r port=%r message=%r>" % (self.host, self.port, self.message)
 
-
 def get_settings(setting):
-    """Reads the specified setting from one of the files listed in the
-    SETTING_FILES variable. The first existing file will be used.
-    If no file in the list exist, an exception will be thrown."""
-    for file_path in SETTINGS_FILES:
-        try:
-            with open(file_path) as settings_file:
-                settings = load(settings_file)
-            return settings[setting]
-        except IOError:
-            continue
-    raise IOError("No clog configuration found (valid paths: {})".format(SETTINGS_FILES))
+    with open(SETTINGS_FILE) as settings_file:
+        settings = load(settings_file)
+    return settings[setting]
 
 
 def find_tail_host(host=None):

--- a/clog/readers.py
+++ b/clog/readers.py
@@ -43,7 +43,7 @@ _chunkfile_pat = re.compile(r'^(?P<stream>[a-z][-a-z0-9_]+)-(?P<year>\d{4})-(?P<
 
 COMPRESSED_HEADER_FMT = "<Q"
 
-SETTINGS_FILE = '/etc/yelp_clog.json'
+SETTINGS_FILE = '/nail/srv/configs/yelp_clog.json'
 
 
 class NoLogDataError(Exception):

--- a/clog/readers.py
+++ b/clog/readers.py
@@ -43,7 +43,9 @@ _chunkfile_pat = re.compile(r'^(?P<stream>[a-z][-a-z0-9_]+)-(?P<year>\d{4})-(?P<
 
 COMPRESSED_HEADER_FMT = "<Q"
 
-SETTINGS_FILE = '/etc/yelp_clog.json'
+# Configuration files. Clog will check them in order,
+# and use the first existing one.
+SETTINGS_FILES = ['/nail/srv/configs/yelp_clog.json', '/etc/yelp_clog.json']
 
 
 class NoLogDataError(Exception):
@@ -176,10 +178,19 @@ class StreamTailerSetupError(Exception):
     def __repr__(self):
         return "<StreamTailerSetupError host=%r port=%r message=%r>" % (self.host, self.port, self.message)
 
+
 def get_settings(setting):
-    with open(SETTINGS_FILE) as settings_file:
-        settings = load(settings_file)
-    return settings[setting]
+    """Reads the specified setting from one of the files listed in the
+    SETTING_FILES variable. The first existing file will be used.
+    If no file in the list exist, an exception will be thrown."""
+    for file_path in SETTINGS_FILES:
+        try:
+            with open(file_path) as settings_file:
+                settings = load(settings_file)
+            return settings[setting]
+        except IOError:
+            continue
+    raise IOError("No clog configuration found (valid paths: {})".format(SETTINGS_FILES))
 
 
 def find_tail_host(host=None):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     extras_require={
         'zipkin': ['py_zipkin'],
         'uwsgi': ['uWSGI'],
-        'internal': ['yelp_meteorite==1.3.0', 'monk==0.3.0']
+        'internal': ['yelp_meteorite==1.3.0', 'monk==0.2.1']
     },
     classifiers=[
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     extras_require={
         'zipkin': ['py_zipkin'],
         'uwsgi': ['uWSGI'],
-        'internal': ['yelp_meteorite==1.3.0', 'monk==0.2.1']
+        'internal': ['yelp_meteorite>=1.3.0,<2.0.0', 'monk>=0.3.0,<0.4.0']
     },
     classifiers=[
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     extras_require={
         'zipkin': ['py_zipkin'],
         'uwsgi': ['uWSGI'],
-        'internal': ['yelp_meteorite==1.3.0', 'monk==0.2.1']
+        'internal': ['yelp_meteorite==1.3.0', 'monk==0.3.0']
     },
     classifiers=[
         'Programming Language :: Python :: 2',

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -168,24 +168,6 @@ class TestFindTailHost(object):
 
         assert tail_host == self.TEST_TAIL_HOST
 
-    @mock.patch('clog.readers.SETTINGS_FILES', ['/____1', '/____2'])
-    def test_get_settings_no_file(self):
-        with pytest.raises(IOError):
-            readers.get_settings('DEFAULT_SCRIBE_TAIL_HOST')
-
-    def test_get_settings(self):
-        with tempfile.NamedTemporaryFile('w') as config_file1, \
-                tempfile.NamedTemporaryFile('w') as config_file2:
-            config_file1.write('{"DEFAULT_SCRIBE_TAIL_HOST": "some_host_1"}')
-            config_file1.flush()
-            config_file2.write('{"DEFAULT_SCRIBE_TAIL_HOST": "some_host_2"}')
-            config_file2.flush()
-            with mock.patch(
-                'clog.readers.SETTINGS_FILES',
-                ['/wrong_file_1', config_file1.name, config_file2.name]
-            ):
-                assert readers.get_settings('DEFAULT_SCRIBE_TAIL_HOST') == 'some_host_1'
-
     def test_with_file_missing(self, mock_get_settings_failed):
         with pytest.raises(Exception):
             readers.find_tail_host(host=self.TEST_HOST)

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -168,6 +168,24 @@ class TestFindTailHost(object):
 
         assert tail_host == self.TEST_TAIL_HOST
 
+    @mock.patch('clog.readers.SETTINGS_FILES', ['/____1', '/____2'])
+    def test_get_settings_no_file(self):
+        with pytest.raises(IOError):
+            readers.get_settings('DEFAULT_SCRIBE_TAIL_HOST')
+
+    def test_get_settings(self):
+        with tempfile.NamedTemporaryFile('w') as config_file1, \
+                tempfile.NamedTemporaryFile('w') as config_file2:
+            config_file1.write('{"DEFAULT_SCRIBE_TAIL_HOST": "some_host_1"}')
+            config_file1.flush()
+            config_file2.write('{"DEFAULT_SCRIBE_TAIL_HOST": "some_host_2"}')
+            config_file2.flush()
+            with mock.patch(
+                'clog.readers.SETTINGS_FILES',
+                ['/wrong_file_1', config_file1.name, config_file2.name]
+            ):
+                assert readers.get_settings('DEFAULT_SCRIBE_TAIL_HOST') == 'some_host_1'
+
     def test_with_file_missing(self, mock_get_settings_failed):
         with pytest.raises(Exception):
             readers.find_tail_host(host=self.TEST_HOST)


### PR DESCRIPTION
Add support to /nail/srv/configs/yelp_clog.json as new configuration path, while adding fallback logic to the old path for backward compatibility.