### PR TITLE
Default to find_tail_host when no host/port is given in StreamTailer

### DIFF
--- a/clog/config.py
+++ b/clog/config.py
@@ -123,6 +123,10 @@ scribe_host = clog_namespace.get_string('scribe_host',
 scribe_port = clog_namespace.get_int('scribe_port',
     help="Port of the scribe server.")
 
+default_scribe_tail_port = clog_namespace.get_int('default_scribe_tail_port',
+    default=3535,
+    help="Default port of scribe tailing services.")
+
 scribe_retry_interval = clog_namespace.get_int('scribe_retry_interval',
     default=10,
     help="Seconds to wait between connection retries.")

--- a/clog/readers.py
+++ b/clog/readers.py
@@ -34,6 +34,7 @@ import signal
 import yaml
 from datetime import timedelta
 from simplejson import load
+from staticconf.errors import ConfigurationError
 from tempfile import TemporaryFile
 
 from clog import config
@@ -251,8 +252,6 @@ class StreamTailer(object):
         help="List of Scribe endpoints for tailing, "
              "in the form {'host': host, 'port': port}")
 
-    default_tail_port = config.default_scribe_tail_port
-
     def __init__(self,
                  stream,
                  host=None,
@@ -271,11 +270,9 @@ class StreamTailer(object):
                 primary_tail_host = random.choice(self.scribe_tail_services)
                 host = primary_tail_host['host']
                 port = primary_tail_host['port']
-            except Exception:
-                # Possible exceptions include IndexError if the list is empty
-                # or ConfigurationError if there is no list in the configuration
+            except (IndexError, ConfigurationError):
                 host = find_tail_host()
-                port = self.default_tail_port.value
+                port = config.default_scribe_tail_port.value
 
         if use_kafka and not host.startswith('scribekafkaservices-'):
             self.host = find_tail_host(host)


### PR DESCRIPTION
If no host/port is given for a StreamTailer, it used to look at the
configuration in the `scribe_tail_services` list. It would fail if
either this list is empty or the configuration cannot be found.

With this change applied, if no configuration can be found, the host
will be discovered using `find_tail_host`. The port can be discovered
thanks to a new configuration parameter (defaults to port 3535).