### PR TITLE
Add scribify to MonkLogger

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+master
+------
+
+* Use scribify function to convert MonkLogger stream names, for
+  backward compatibility with ScribeLogger.
+
 2.14.0
 ------
 

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -289,6 +289,8 @@ class MonkLogger(object):
         if backend not in ('monk', 'dual'):
             return
 
+        # For backward-compatibility with the ScribeLogger
+        stream = scribify(stream)
         if len(line) <= MAX_MONK_LINE_SIZE_IN_BYTES:
             self._log_line_no_size_limit(stream, line)
         else:


### PR DESCRIPTION
Use the scribify function to convert user-provided stream names into scribe category names. This will ensure that MonkLogger is fully backward compatible with the ScribeLogger.