### PR TITLE
Add memory buffering logic to MonkLogger

### DIFF
--- a/clog/config.py
+++ b/clog/config.py
@@ -123,6 +123,10 @@ monk_timeout_backoff_ms = clog_namespace.get_int('monk_timeout_backoff_ms',
     help=("After a timeout occurs, clog won't write to Monk for as many "
           "milliseconds as defined here"))
 
+monk_timeout_backoff_jitter_ms = clog_namespace.get_int('monk_timeout_backoff_jitter_ms',
+    default=100,
+    help="Jitter time after timeout backoff passed")
+
 monk_use_memory_buffer = clog_namespace.get_bool('monk_use_memory_buffer',
     default=False,
     help="Add lines to a memory buffer in case of a timeout.")
@@ -130,10 +134,6 @@ monk_use_memory_buffer = clog_namespace.get_bool('monk_use_memory_buffer',
 monk_memory_buffer_max_bytes = clog_namespace.get_int('monk_memory_buffer_max_bytes',
     default=10 * 1024 * 1024,
     help="(Approximate) Maximum size of the memory buffer.")
-
-monk_buffering_time_ms = clog_namespace.get_int('monk_buffering_time_ms',
-    default=500,
-    help="Time to buffer data for. After this time, buffer will try to be flushed.")
 
 scribe_host = clog_namespace.get_string('scribe_host',
     help="Hostname of the scribe server.")

--- a/clog/config.py
+++ b/clog/config.py
@@ -123,6 +123,18 @@ monk_timeout_backoff_ms = clog_namespace.get_int('monk_timeout_backoff_ms',
     help=("After a timeout occurs, clog won't write to Monk for as many "
           "milliseconds as defined here"))
 
+monk_use_memory_buffer = clog_namespace.get_bool('monk_use_memory_buffer',
+    default=False,
+    help="Add lines to a memory buffer in case of a timeout.")
+
+monk_memory_buffer_max_bytes = clog_namespace.get_int('monk_memory_buffer_max_bytes',
+    default=10 * 1024 * 1024,
+    help="(Approximate) Maximum size of the memory buffer.")
+
+monk_buffering_time_ms = clog_namespace.get_int('monk_buffering_time_ms',
+    default=500,
+    help="Time to buffer data for. After this time, buffer will try to be flushed.")
+
 scribe_host = clog_namespace.get_string('scribe_host',
     help="Hostname of the scribe server.")
 

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -333,7 +333,6 @@ class MonkLogger(object):
                 if self.use_buffer:
                     self.buffering = True
                     self.report_status(False, 'Start buffering')
-                    self.metrics.monk_buffer()
                     self._add_to_buffer(stream, line)
 
     def _add_to_buffer(self, stream, line):

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -350,7 +350,7 @@ class MonkLogger(object):
         for _ in six.moves.range(len(self.buffer)):
             stream, line = self.buffer.popleft()
             self.buffer_bytes -= len(line)
-            self.log_line(stream, line)
+            self._log_line_no_size_limit(stream, line)
 
     def close(self):
         self._flush_buffer()

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -305,18 +305,14 @@ class MonkLogger(object):
 
     def _log_line_no_size_limit(self, stream, line):
         now = time.time()
-
-        if self.buffering:
-            if now - self.last_disconnect < self.timeout_backoff_s:
-                self._add_to_buffer(stream, line)
-                return
-            else:
-                self.buffering = False
-                self._flush_buffer()
-                self.report_status(False, 'Flushed buffer ({} left)'.format(len(self.buffer)))
-
         if now - self.last_disconnect < self.timeout_backoff_s:
+            if self.buffering:
+                self._add_to_buffer(stream, line)
             return
+        elif self.buffering:
+            self.buffering = False
+            self._flush_buffer()
+            self.report_status(False, 'Flushed buffer ({} left)'.format(len(self.buffer)))
 
         with self.metrics.sampled_request():
             try:

--- a/clog/metrics_reporter.py
+++ b/clog/metrics_reporter.py
@@ -43,7 +43,6 @@ LOG_LINE_SENT = 'log_line.sent'
 LOG_LINE_LATENCY = 'log_line.latency_microseconds'
 LOG_LINE_MONK_EXCEPTION = 'log_line.monk_exception'
 LOG_LINE_MONK_TIMEOUT = 'log_line.monk_timeout'
-LOG_LINE_MONK_BUFFER = 'log_line.monk_buffer'
 
 
 def _create_or_fake_counter(*args, **kwargs):
@@ -93,10 +92,6 @@ class MetricsReporter(object):
             METRICS_TOTAL_PREFIX + LOG_LINE_MONK_TIMEOUT,
             default_dimensions
         )
-        self._monk_buffer_counter = _create_or_fake_counter(
-            METRICS_TOTAL_PREFIX + LOG_LINE_MONK_BUFFER,
-            default_dimensions
-        )
         self._sample_rate = sample_rate
         self._lock = threading.RLock()
 
@@ -127,8 +122,3 @@ class MetricsReporter(object):
         """Increases the monk timeout counter by 1"""
         with self._lock:
             self._monk_timeout_counter.count(1)
-
-    def monk_buffer(self):
-        """Increases the monk line buffering counter by 1"""
-        with self._lock:
-            self._monk_buffer_counter.count(1)

--- a/clog/metrics_reporter.py
+++ b/clog/metrics_reporter.py
@@ -43,6 +43,7 @@ LOG_LINE_SENT = 'log_line.sent'
 LOG_LINE_LATENCY = 'log_line.latency_microseconds'
 LOG_LINE_MONK_EXCEPTION = 'log_line.monk_exception'
 LOG_LINE_MONK_TIMEOUT = 'log_line.monk_timeout'
+LOG_LINE_MONK_BUFFER = 'log_line.monk_buffer'
 
 
 def _create_or_fake_counter(*args, **kwargs):
@@ -92,6 +93,10 @@ class MetricsReporter(object):
             METRICS_TOTAL_PREFIX + LOG_LINE_MONK_TIMEOUT,
             default_dimensions
         )
+        self._monk_buffer_counter = _create_or_fake_counter(
+            METRICS_TOTAL_PREFIX + LOG_LINE_MONK_BUFFER,
+            default_dimensions
+        )
         self._sample_rate = sample_rate
         self._lock = threading.RLock()
 
@@ -122,3 +127,8 @@ class MetricsReporter(object):
         """Increases the monk timeout counter by 1"""
         with self._lock:
             self._monk_timeout_counter.count(1)
+
+    def monk_buffer(self):
+        """Increases the monk line buffering counter by 1"""
+        with self._lock:
+            self._monk_buffer_counter.count(1)

--- a/tests/test_clog.py
+++ b/tests/test_clog.py
@@ -207,9 +207,13 @@ class TestCLogMonkLogger(object):
     @pytest.yield_fixture(autouse=True)
     def setup(self):
         self.stream = 'test.stream'
+        self.producer = mock.MagicMock()
         loggers.MonkProducer = mock.Mock()
         self.logger = MonkLogger('clog_test_client_id')
         self.logger.report_status = mock.Mock()
+        self.logger.producer = self.producer
+        self.logger.use_buffer = True
+        self.logger.maximum_buffer_bytes = 100 * 1024 * 1024
 
     @mock.patch('clog.loggers.MonkLogger._log_line_no_size_limit', autospec=True)
     def test_category_name_conversion(self, mock_log_line_no_size_limit):
@@ -217,19 +221,6 @@ class TestCLogMonkLogger(object):
         self.logger.log_line(self.stream, line)
         call_1 = mock.call(mock.ANY, "test_stream", line)
         mock_log_line_no_size_limit.assert_has_calls([call_1])
-
-
-class TestCLogMonkMemoryLogger(object):
-
-    @pytest.yield_fixture(autouse=True)
-    def setup(self):
-        self.stream = 'test.stream'
-        self.producer = mock.MagicMock()
-        loggers.MonkProducer = mock.Mock()
-        self.logger = MonkLogger('clog_test_client_id')
-        self.logger.producer = self.producer
-        self.logger.use_buffer = True
-        self.logger.maximum_buffer_bytes = 100 * 1024 * 1024
 
     def test_logger_fine(self):
         self.logger.log_line(self.stream, 'content')

--- a/tests/test_clog.py
+++ b/tests/test_clog.py
@@ -222,10 +222,9 @@ class TestCLogMonkLogger(object):
 class TestCLogMonkMemoryLogger(object):
 
     @pytest.yield_fixture(autouse=True)
-    @mock.patch('monk.producers.MonkProducer', autospec=True)
-    def setup(self, producer):
+    def setup(self):
         self.stream = 'test.stream'
-        self.producer = producer
+        self.producer = mock.MagicMock()
         loggers.MonkProducer = mock.Mock()
         self.logger = MonkLogger('clog_test_client_id')
         self.logger.producer = self.producer

--- a/tests/test_clog.py
+++ b/tests/test_clog.py
@@ -217,3 +217,87 @@ class TestCLogMonkLogger(object):
         self.logger.log_line(self.stream, line)
         call_1 = mock.call(mock.ANY, "test_stream", line)
         mock_log_line_no_size_limit.assert_has_calls([call_1])
+
+
+class TestCLogMonkMemoryLogger(object):
+
+    @pytest.yield_fixture(autouse=True)
+    @mock.patch('monk.producers.MonkProducer', autospec=True)
+    def setup(self, producer):
+        self.stream = 'test.stream'
+        self.producer = producer
+        loggers.MonkProducer = mock.Mock()
+        self.logger = MonkLogger('clog_test_client_id')
+        self.logger.producer = self.producer
+        self.logger.use_buffer = True
+        self.logger.maximum_buffer_bytes = 100 * 1024 * 1024
+        self.logger.buffering_time_s = 5
+
+    def test_logger_fine(self):
+        # self.producer.send_messages.side_effect = ()
+        self.logger.log_line(self.stream, 'content')
+        assert self.producer.send_messages.call_count == 1
+
+    def test_logger_disconnect(self):
+        self.producer.send_messages.side_effect = ((), Exception(), Exception())
+
+        for i in range(3):
+            self.logger.log_line(self.stream, 'content{}'.format(i))
+
+        assert self.producer.send_messages.call_count == 2
+        assert len(self.logger.buffer) == 2
+
+    def test_logger_reconnect(self):
+        self.logger.buffering_time_s = 0
+        self.producer.send_messages.side_effect = (Exception(), (), ())
+
+        self.logger.log_line(self.stream, 'content1')
+
+        assert len(self.logger.buffer) == 1
+
+        self.logger.log_line(self.stream, 'content2')
+
+        assert self.producer.send_messages.call_count == 3
+        assert len(self.logger.buffer) == 0
+
+    def test_memory_bytes(self):
+        self.producer.send_messages.return_value = True
+
+        assert self.logger.buffer_bytes == 0
+
+        for _ in range(10):
+            self.logger._add_to_buffer(self.stream, 'content')
+
+        assert self.logger.buffer_bytes == len('content') * 10
+
+        self.logger._flush_buffer()
+
+        assert self.logger.buffer_bytes == 0
+
+    def test_eviction(self):
+        self.logger.maximum_buffer_bytes = 10
+
+        for _ in range(3):
+            self.logger._add_to_buffer(self.stream, 'a' * 5)
+
+        assert len(self.logger.buffer) == 2
+
+        self.logger._add_to_buffer(self.stream, 'a' * 15)
+
+        assert len(self.logger.buffer) == 1
+
+    def test_reenqueue(self):
+        self.producer.send_messages.side_effect = Exception()
+
+        for i in range(10):
+            self.logger.log_line(self.stream, 'content{}'.format(i))
+
+        assert len(self.logger.buffer) == 10
+        assert self.producer.send_messages.call_count == 1
+
+        # If the connection is still down, ensure all lines are re-buffered once
+        self.logger.buffering = False
+        self.logger._flush_buffer()
+
+        assert len(self.logger.buffer) == 10
+        assert self.producer.send_messages.call_count == 2

--- a/tests/test_clog.py
+++ b/tests/test_clog.py
@@ -293,7 +293,6 @@ class TestCLogMonkMemoryLogger(object):
         assert self.producer.send_messages.call_count == 1
 
         # If the connection is still down, ensure all lines are re-buffered once
-        self.logger.buffering = False
         self.logger.last_disconnect = 0
         self.logger._flush_buffer()
 


### PR DESCRIPTION
If the producer fails (e.g: Monk is restarting and is down for a while),
start buffering log lines in memory, up to a certain size threshold
(older messages will be dropped if the size of the buffer grows too much).

Buffering will stop after a configurable amount of time, all buffered
log lines will be flushed back into Monk (this would slow down the
.log_line call when flushing happens, but it should not be too much of a
trouble). If the producer fails again during flushing, all lines will be
added back to the buffer.

One datapoint is emitted every time buffering starts (maybe I should emit
one when flushing as well?) 

This does not handle STREAM_NOT_FOUND use case (it will start
buffering), but this will be tackled later I suppose.