### PR TITLE
Send errors to syslog using udp instead of unix socket

### DIFF
--- a/clog/config.py
+++ b/clog/config.py
@@ -153,6 +153,10 @@ scribe_errors_to_syslog = clog_namespace.get_bool('scribe_errors_to_syslog',
     default=False,
     help="If True, send Scribe errors to syslog, otherwise to stderr")
 
+syslog_host_address = clog_namespace.get_string('syslog_host_address',
+    default='127.0.0.1',
+    help="Address of the syslog host, if needed")
+
 scribe_logging_timeout = clog_namespace.get_int('scribe_logging_timeout',
     default=1000,
     help="Milliseconds to time out scribe logging")

--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -113,6 +113,7 @@ def report_to_syslog(is_error, msg):
     if is_error:
         logger = logging.getLogger('clog-syslog')
         if len(logger.handlers) == 0:
+            logger.propagate = False  # Prevent errors from being logged via CLogHandler :)
             logger.addHandler(SysLogHandler(
                 address=(config.syslog_host_address.value, SYSLOG_UDP_PORT),
                 facility=SysLogHandler.LOG_USER,


### PR DESCRIPTION
This will allow yelp_clog errors to be reported even from docker
containers. The syslog host can be configured using
`syslog_host_address`, we will probably want to set it to yocalhost.

The `SysLogHandler` in python2 does not support adding `ident` to messages, however the ident is just set by prefixing the message by `ident: `

L129-136 of https://www.retro11.de/ouxr/211bsd/usr/src/lib/libc/gen/syslog.c.html

https://docs.python.org/2/library/logging.handlers.html#sysloghandler
https://docs.python.org/3/library/logging.handlers.html#sysloghandler