### PR TITLE
Flush buffer only if buffering is in progress

### DIFF
--- a/clog/loggers.py
+++ b/clog/loggers.py
@@ -307,7 +307,7 @@ class MonkLogger(object):
         if now - self.last_disconnect < self.timeout_backoff_s:
             self._add_to_buffer(stream, line)
             return
-        elif can_flush_buffer and self.use_buffer:
+        elif can_flush_buffer and self.use_buffer and len(self.buffer) > 0:
             self._flush_buffer()
             self.report_status(False, 'Flushed buffer ({} left)'.format(len(self.buffer)))
 


### PR DESCRIPTION
Without this condition, turning on buffering would flush all the time, reporting rubish to syslog